### PR TITLE
[cross-repo-apply] Add Safety Rules and Review/Escalation sections to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -177,3 +177,24 @@ From `git log`:
 - Consumer-facing README and Podfile template: `README.md`
 - Per-pod commercial/MIT licenses: `Sources/<Pod>/LICENSE` (Core, Messenger) and the OSS-fork sources for the rest
 - Upstream XCFramework releases: `https://github.com/sendbird/delight-ai-agent-core-ios/releases`
+
+## Safety Rules
+
+- Do not make destructive or irreversible changes without explicit approval.
+- Do not bypass branch protection, required checks, required reviewers, scanners, or tests.
+- Do not force-push to protected branches or someone else's branch.
+- Do not commit secrets, tokens, credentials, customer data, or private keys.
+- Do not weaken authentication, authorization, IAM/RBAC, TLS, crypto, network exposure, or data-access controls without explicit approval.
+- Do not disable TLS verification except in clearly dev-only code with a written rationale.
+- Do not log secrets, auth headers, cookies, payment data, or customer PII.
+- Use synthetic test data; do not add real customer data to tests, fixtures, or seed files.
+
+## Review And Escalation
+
+Stop and ask before changing:
+
+- production data, infra, deploy, or config
+- secrets, auth, IAM, network exposure, or crypto
+- public APIs or compatibility-sensitive behavior
+- dependency/security scanner configuration
+- anything destructive or hard to roll back


### PR DESCRIPTION
## Cross-Repo Apply

**변경 설명:** Add Safety Rules and Review/Escalation sections to AGENTS.md

**적용 대상:** iOS distribution repo

### 변경 내용

`AGENTS.md` 끝에 다음 두 섹션을 추가합니다:

- `## Safety Rules` — 파괴적 변경 / 시크릿 / 인증·인가·암호화 / TLS / 로깅 / 테스트 데이터 가드레일 8개 항목
- `## Review And Escalation` — production data, secrets/auth/IAM, public API, scanner config, 비가역 변경 시 사전 확인 목록

---

> [cross-repo-apply] 일괄 변경 — `/sendbird-internal-plugin:cross-repo-apply` 로 생성됨