### PR TITLE
[CLNP-8562] Trace private spec publisher requests

### DIFF
--- a/.github/workflows/private-spec-publisher.yml
+++ b/.github/workflows/private-spec-publisher.yml
@@ -1,4 +1,5 @@
 name: Private Spec Publisher
+run-name: Private spec ${{ inputs.pod_name }} ${{ inputs.version }} (${{ inputs.request_id || github.run_id }})
 
 on:
   workflow_dispatch:
@@ -20,6 +21,11 @@ on:
         required: true
         default: true
         type: boolean
+      request_id:
+        description: Optional caller-provided identifier for tracing cross-repo dispatches
+        required: false
+        default: ""
+        type: string
 
 permissions:
   contents: write
@@ -34,6 +40,18 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+
+      - name: Print request context
+        env:
+          POD_NAME: ${{ inputs.pod_name }}
+          VERSION: ${{ inputs.version }}
+          DRY_RUN: ${{ inputs.dry_run }}
+          REQUEST_ID: ${{ inputs.request_id }}
+        run: |
+          echo "pod_name=$POD_NAME"
+          echo "version=$VERSION"
+          echo "dry_run=$DRY_RUN"
+          echo "request_id=${REQUEST_ID:-$GITHUB_RUN_ID}"
 
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1


### PR DESCRIPTION
## Summary
- Add run-name and request_id input to the private spec publisher workflow for cross-repo dispatch traceability.
- Print request context before validation so AuthSDK release runs are easier to correlate.

## Test Plan
- ruby -c scripts/private_spec_publisher.rb
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/private-spec-publisher.yml")'
- ruby scripts/private_spec_publisher.rb --podspec Specs/SendbirdAuthSDK/1.1.2/SendbirdAuthSDK.podspec --pod SendbirdAuthSDK --version 1.1.2 --dry-run