### PR TITLE
Simplify private spec publisher auto merge

### DIFF
--- a/.github/workflows/private-spec-publisher.yml
+++ b/.github/workflows/private-spec-publisher.yml
@@ -15,6 +15,11 @@ on:
         description: Base64-encoded generated podspec
         required: true
         type: string
+      dry_run:
+        description: Create or update the PR without approving or enabling auto-merge
+        required: false
+        default: false
+        type: boolean
 
 permissions:
   contents: write
@@ -145,7 +150,7 @@ jobs:
           echo "pr_url=$pr_url" >> "$GITHUB_OUTPUT"
 
       - name: Approve private spec PR
-        if: ${{ steps.pull_request.outputs.pr_url != '' }}
+        if: ${{ !inputs.dry_run && steps.pull_request.outputs.pr_url != '' }}
         env:
           GH_TOKEN: ${{ secrets.GH_TOKEN_FOR_PR_APPROVAL }}
         run: |
@@ -161,7 +166,7 @@ jobs:
             --body "Approved by private spec publisher automation."
 
       - name: Enable auto-merge
-        if: ${{ steps.pull_request.outputs.pr_url != '' }}
+        if: ${{ !inputs.dry_run && steps.pull_request.outputs.pr_url != '' }}
         env:
           GH_TOKEN: ${{ github.token }}
         run: |

--- a/.github/workflows/private-spec-publisher.yml
+++ b/.github/workflows/private-spec-publisher.yml
@@ -15,11 +15,6 @@ on:
         description: Base64-encoded generated podspec
         required: true
         type: string
-      dry_run:
-        description: Validate only; do not branch, commit, push, or open a PR
-        required: true
-        default: true
-        type: boolean
 
 permissions:
   contents: write
@@ -76,7 +71,6 @@ jobs:
           echo "destination: $destination"
 
       - name: Prepare publish branch
-        if: ${{ !inputs.dry_run }}
         env:
           POD_NAME: ${{ steps.validate.outputs.pod_name }}
           VERSION: ${{ steps.validate.outputs.version }}
@@ -96,7 +90,6 @@ jobs:
           echo "PUBLISH_BRANCH=$branch" >> "$GITHUB_ENV"
 
       - name: Publish private spec
-        if: ${{ !inputs.dry_run }}
         id: publish
         env:
           DESTINATION: ${{ steps.validate.outputs.destination }}
@@ -106,7 +99,6 @@ jobs:
           echo "destination=$DESTINATION" >> "$GITHUB_OUTPUT"
 
       - name: Commit and push private spec
-        if: ${{ !inputs.dry_run }}
         env:
           DESTINATION: ${{ steps.publish.outputs.destination }}
           POD_NAME: ${{ steps.validate.outputs.pod_name }}
@@ -127,7 +119,6 @@ jobs:
 
       - name: Open or update private spec PR
         id: pull_request
-        if: ${{ !inputs.dry_run }}
         env:
           GH_TOKEN: ${{ github.token }}
           DESTINATION: ${{ steps.publish.outputs.destination }}
@@ -152,3 +143,31 @@ jobs:
           fi
 
           echo "pr_url=$pr_url" >> "$GITHUB_OUTPUT"
+
+      - name: Approve private spec PR
+        if: ${{ steps.pull_request.outputs.pr_url != '' }}
+        env:
+          GH_TOKEN: ${{ secrets.GH_TOKEN_FOR_PR_APPROVAL }}
+        run: |
+          set -euo pipefail
+
+          if [[ -z "${GH_TOKEN:-}" ]]; then
+            echo "GH_TOKEN_FOR_PR_APPROVAL is required to approve private spec PRs." >&2
+            exit 1
+          fi
+
+          gh pr review "$PUBLISH_BRANCH" \
+            --approve \
+            --body "Approved by private spec publisher automation."
+
+      - name: Enable auto-merge
+        if: ${{ steps.pull_request.outputs.pr_url != '' }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+
+          gh pr merge "$PUBLISH_BRANCH" \
+            --auto \
+            --squash \
+            --delete-branch


### PR DESCRIPTION
## Summary
- remove dry_run from private spec publisher workflow
- always publish on workflow dispatch
- approve private spec PRs with GH_TOKEN_FOR_PR_APPROVAL
- enable GitHub auto-merge with squash and branch deletion

## Tests
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/private-spec-publisher.yml"); puts "YAML OK"'
- git diff --check