### PR TITLE
Add request_id input and run-name to private spec publisher

### DIFF
--- a/.github/workflows/private-spec-publisher.yml
+++ b/.github/workflows/private-spec-publisher.yml
@@ -1,5 +1,7 @@
 name: Private Spec Publisher
 
+run-name: "Private Spec Publisher ${{ inputs.pod_name }} ${{ inputs.version }} [rid:${{ inputs.request_id }}]"
+
 on:
   workflow_dispatch:
     inputs:
@@ -20,6 +22,11 @@ on:
         required: false
         default: false
         type: boolean
+      request_id:
+        description: Caller-supplied correlation id, echoed into run-name so the dispatcher can locate this exact run
+        required: false
+        default: ""
+        type: string
 
 permissions:
   contents: write
@@ -46,6 +53,7 @@ jobs:
         env:
           POD_NAME: ${{ inputs.pod_name }}
           VERSION: ${{ inputs.version }}
+          REQUEST_ID: ${{ inputs.request_id }}
         run: |
           set -euo pipefail
 
@@ -74,6 +82,7 @@ jobs:
           echo "pod: $pod_name"
           echo "version: $version"
           echo "destination: $destination"
+          echo "request_id: ${REQUEST_ID:-<none>}"
 
       - name: Prepare publish branch
         env:


### PR DESCRIPTION
## What

Adds a `request_id` correlation mechanism to the private spec publisher so SDK release workflows can locate and observe the exact downstream publisher run they dispatched.

- New optional `request_id` workflow_dispatch input (empty default — backward compatible with callers that don't pass it yet)
- Top-level `run-name` embeds `[rid:<request_id>]` so dispatchers can match the run via its `displayTitle`
- Echoes `request_id` in the validation step logs for human debugging

## Why

Today chat-ios / auth-ios release workflows dispatch this publisher fire-and-forget and never observe the result, so a publisher failure leaves the release green. This is the publisher-side half of CLNP-8578: it gives callers a stable anchor to find their run. `gh workflow run` doesn't return a run id, so the request_id in the run-name is how the caller re-discovers it.

## Scope

Publisher-side only. The caller-side changes (passing the request_id from chat-ios, plus the watch step that waits on the run and propagates failure) land as separate PRs in chat-ios / auth-ios. Roll this out **first** — if the publisher lacks the run-name, callers can't match their run.

Note: observation is scoped to the publisher **run** concluding, not the spec PR actually merging (auto-merge completes asynchronously by design).

CLNP-8578