### PR TITLE
Backfill private specs for Auth/Chat/UIKit/MessageTemplate

### DIFF
--- a/Specs/SendBirdUIKit/3.32.1/SendBirdUIKit.podspec
+++ b/Specs/SendBirdUIKit/3.32.1/SendBirdUIKit.podspec
@@ -1,0 +1,31 @@
+Pod::Spec.new do |s|
+  s.name = 'SendBirdUIKit'
+  s.version = '3.32.1'
+  s.summary = 'Sendbird UIKit iOS Framework'
+  s.description = 'UIKit module for Sendbird iOS SDK'
+  s.homepage = 'https://sendbird.com'
+  s.license = { :type => 'Commercial', :file => 'SendBirdUIKit/LICENSE.md' }
+  s.authors = {
+    'Sendbird' => 'sha.sdk_deployment@sendbird.com',
+    'Jed Gyeong' => 'jed.gyeong@sendbird.com',
+    'Celine Moon' => 'celine.moon@sendbird.com',
+    'Tez Park' => 'tez.park@sendbird.com',
+    'Damon Park' => 'damon.park@sendbird.com',
+    'Young Hwang' => 'young.hwang@sendbird.com',
+    'Kai Lee' => 'kai.lee@sendbird.com'
+  }
+  s.source = {
+    :http => 'https://github.com/sendbird/sendbird-uikit-ios/releases/download/3.32.1/SendBirdUIKit.zip',
+    :sha1 => '05dbf11b35ff5f32931c353cdf37e8eea94f1107'
+  }
+  s.requires_arc = true
+  s.platform = :ios, '13.0'
+  s.documentation_url = 'https://sendbird.com/docs/uikit'
+  s.ios.vendored_frameworks = 'SendBirdUIKit/SendbirdUIKit.xcframework'
+  s.dependency 'SendbirdChatSDK', '>= 4.29.2'
+  s.dependency 'SendbirdUIMessageTemplate', '>= 3.32.1'
+  s.ios.frameworks = ['UIKit', 'Foundation', 'CoreData', 'SendbirdChatSDK']
+  s.ios.library = 'icucore'
+  s.pod_target_xcconfig = { 'ENABLE_USER_SCRIPT_SANDBOXING' => 'NO' }
+  s.user_target_xcconfig = { 'ENABLE_USER_SCRIPT_SANDBOXING' => 'NO' }
+end

--- a/Specs/SendBirdUIKit/3.32.2/SendBirdUIKit.podspec
+++ b/Specs/SendBirdUIKit/3.32.2/SendBirdUIKit.podspec
@@ -1,0 +1,31 @@
+Pod::Spec.new do |s|
+  s.name = 'SendBirdUIKit'
+  s.version = '3.32.2'
+  s.summary = 'Sendbird UIKit iOS Framework'
+  s.description = 'UIKit module for Sendbird iOS SDK'
+  s.homepage = 'https://sendbird.com'
+  s.license = { :type => 'Commercial', :file => 'SendBirdUIKit/LICENSE.md' }
+  s.authors = {
+    'Sendbird' => 'sha.sdk_deployment@sendbird.com',
+    'Jed Gyeong' => 'jed.gyeong@sendbird.com',
+    'Celine Moon' => 'celine.moon@sendbird.com',
+    'Tez Park' => 'tez.park@sendbird.com',
+    'Damon Park' => 'damon.park@sendbird.com',
+    'Young Hwang' => 'young.hwang@sendbird.com',
+    'Kai Lee' => 'kai.lee@sendbird.com'
+  }
+  s.source = {
+    :http => 'https://github.com/sendbird/sendbird-uikit-ios/releases/download/3.32.2/SendBirdUIKit.zip',
+    :sha1 => 'ba9646278f198e8ae13e50db903431ba595a313f'
+  }
+  s.requires_arc = true
+  s.platform = :ios, '13.0'
+  s.documentation_url = 'https://sendbird.com/docs/uikit'
+  s.ios.vendored_frameworks = 'SendBirdUIKit/SendbirdUIKit.xcframework'
+  s.dependency 'SendbirdChatSDK', '>= 4.29.2'
+  s.dependency 'SendbirdUIMessageTemplate', '>= 3.32.2'
+  s.ios.frameworks = ['UIKit', 'Foundation', 'CoreData', 'SendbirdChatSDK']
+  s.ios.library = 'icucore'
+  s.pod_target_xcconfig = { 'ENABLE_USER_SCRIPT_SANDBOXING' => 'NO' }
+  s.user_target_xcconfig = { 'ENABLE_USER_SCRIPT_SANDBOXING' => 'NO' }
+end

--- a/Specs/SendBirdUIKit/3.32.3/SendBirdUIKit.podspec
+++ b/Specs/SendBirdUIKit/3.32.3/SendBirdUIKit.podspec
@@ -1,0 +1,31 @@
+Pod::Spec.new do |s|
+  s.name = 'SendBirdUIKit'
+  s.version = '3.32.3'
+  s.summary = 'Sendbird UIKit iOS Framework'
+  s.description = 'UIKit module for Sendbird iOS SDK'
+  s.homepage = 'https://sendbird.com'
+  s.license = { :type => 'Commercial', :file => 'SendBirdUIKit/LICENSE.md' }
+  s.authors = {
+    'Sendbird' => 'sha.sdk_deployment@sendbird.com',
+    'Jed Gyeong' => 'jed.gyeong@sendbird.com',
+    'Celine Moon' => 'celine.moon@sendbird.com',
+    'Tez Park' => 'tez.park@sendbird.com',
+    'Damon Park' => 'damon.park@sendbird.com',
+    'Young Hwang' => 'young.hwang@sendbird.com',
+    'Kai Lee' => 'kai.lee@sendbird.com'
+  }
+  s.source = {
+    :http => 'https://github.com/sendbird/sendbird-uikit-ios/releases/download/3.32.3/SendBirdUIKit.zip',
+    :sha1 => '8dfd977a2031ba8f855f45831af54b0d807a5893'
+  }
+  s.requires_arc = true
+  s.platform = :ios, '13.0'
+  s.documentation_url = 'https://sendbird.com/docs/uikit'
+  s.ios.vendored_frameworks = 'SendBirdUIKit/SendbirdUIKit.xcframework'
+  s.dependency 'SendbirdChatSDK', '>= 4.31.1'
+  s.dependency 'SendbirdUIMessageTemplate', '>= 3.32.3'
+  s.ios.frameworks = ['UIKit', 'Foundation', 'CoreData', 'SendbirdChatSDK']
+  s.ios.library = 'icucore'
+  s.pod_target_xcconfig = { 'ENABLE_USER_SCRIPT_SANDBOXING' => 'NO' }
+  s.user_target_xcconfig = { 'ENABLE_USER_SCRIPT_SANDBOXING' => 'NO' }
+end

--- a/Specs/SendBirdUIKit/3.32.4/SendBirdUIKit.podspec
+++ b/Specs/SendBirdUIKit/3.32.4/SendBirdUIKit.podspec
@@ -1,0 +1,31 @@
+Pod::Spec.new do |s|
+  s.name = 'SendBirdUIKit'
+  s.version = '3.32.4'
+  s.summary = 'Sendbird UIKit iOS Framework'
+  s.description = 'UIKit module for Sendbird iOS SDK'
+  s.homepage = 'https://sendbird.com'
+  s.license = { :type => 'Commercial', :file => 'SendBirdUIKit/LICENSE.md' }
+  s.authors = {
+    'Sendbird' => 'sha.sdk_deployment@sendbird.com',
+    'Jed Gyeong' => 'jed.gyeong@sendbird.com',
+    'Celine Moon' => 'celine.moon@sendbird.com',
+    'Tez Park' => 'tez.park@sendbird.com',
+    'Damon Park' => 'damon.park@sendbird.com',
+    'Young Hwang' => 'young.hwang@sendbird.com',
+    'Kai Lee' => 'kai.lee@sendbird.com'
+  }
+  s.source = {
+    :http => 'https://github.com/sendbird/sendbird-uikit-ios/releases/download/3.32.4/SendBirdUIKit.zip',
+    :sha1 => '316aae725855022c75cc3ba6be6e3ce38e4cee6b'
+  }
+  s.requires_arc = true
+  s.platform = :ios, '13.0'
+  s.documentation_url = 'https://sendbird.com/docs/uikit'
+  s.ios.vendored_frameworks = 'SendBirdUIKit/SendbirdUIKit.xcframework'
+  s.dependency 'SendbirdChatSDK', '>= 4.34.1'
+  s.dependency 'SendbirdUIMessageTemplate', '>= 3.32.4'
+  s.ios.frameworks = ['UIKit', 'Foundation', 'CoreData', 'SendbirdChatSDK']
+  s.ios.library = 'icucore'
+  s.pod_target_xcconfig = { 'ENABLE_USER_SCRIPT_SANDBOXING' => 'NO' }
+  s.user_target_xcconfig = { 'ENABLE_USER_SCRIPT_SANDBOXING' => 'NO' }
+end

--- a/Specs/SendBirdUIKit/3.33.0/SendBirdUIKit.podspec
+++ b/Specs/SendBirdUIKit/3.33.0/SendBirdUIKit.podspec
@@ -1,0 +1,31 @@
+Pod::Spec.new do |s|
+  s.name = 'SendBirdUIKit'
+  s.version = '3.33.0'
+  s.summary = 'Sendbird UIKit iOS Framework'
+  s.description = 'UIKit module for Sendbird iOS SDK'
+  s.homepage = 'https://sendbird.com'
+  s.license = { :type => 'Commercial', :file => 'SendBirdUIKit/LICENSE.md' }
+  s.authors = {
+    'Sendbird' => 'sha.sdk_deployment@sendbird.com',
+    'Jed Gyeong' => 'jed.gyeong@sendbird.com',
+    'Celine Moon' => 'celine.moon@sendbird.com',
+    'Tez Park' => 'tez.park@sendbird.com',
+    'Damon Park' => 'damon.park@sendbird.com',
+    'Young Hwang' => 'young.hwang@sendbird.com',
+    'Kai Lee' => 'kai.lee@sendbird.com'
+  }
+  s.source = {
+    :http => 'https://github.com/sendbird/sendbird-uikit-ios/releases/download/3.33.0/SendBirdUIKit.zip',
+    :sha1 => 'cd467d9c3e1962fb9d7d27e456dd1691711a37bc'
+  }
+  s.requires_arc = true
+  s.platform = :ios, '13.0'
+  s.documentation_url = 'https://sendbird.com/docs/uikit'
+  s.ios.vendored_frameworks = 'SendBirdUIKit/SendbirdUIKit.xcframework'
+  s.dependency 'SendbirdChatSDK', '>= 4.35.0'
+  s.dependency 'SendbirdUIMessageTemplate', '>= 3.33.0'
+  s.ios.frameworks = ['UIKit', 'Foundation', 'CoreData', 'SendbirdChatSDK']
+  s.ios.library = 'icucore'
+  s.pod_target_xcconfig = { 'ENABLE_USER_SCRIPT_SANDBOXING' => 'NO' }
+  s.user_target_xcconfig = { 'ENABLE_USER_SCRIPT_SANDBOXING' => 'NO' }
+end

--- a/Specs/SendBirdUIKit/3.33.1/SendBirdUIKit.podspec
+++ b/Specs/SendBirdUIKit/3.33.1/SendBirdUIKit.podspec
@@ -1,0 +1,31 @@
+Pod::Spec.new do |s|
+  s.name = 'SendBirdUIKit'
+  s.version = '3.33.1'
+  s.summary = 'Sendbird UIKit iOS Framework'
+  s.description = 'UIKit module for Sendbird iOS SDK'
+  s.homepage = 'https://sendbird.com'
+  s.license = { :type => 'Commercial', :file => 'SendBirdUIKit/LICENSE.md' }
+  s.authors = {
+    'Sendbird' => 'sha.sdk_deployment@sendbird.com',
+    'Jed Gyeong' => 'jed.gyeong@sendbird.com',
+    'Celine Moon' => 'celine.moon@sendbird.com',
+    'Tez Park' => 'tez.park@sendbird.com',
+    'Damon Park' => 'damon.park@sendbird.com',
+    'Young Hwang' => 'young.hwang@sendbird.com',
+    'Kai Lee' => 'kai.lee@sendbird.com'
+  }
+  s.source = {
+    :http => 'https://github.com/sendbird/sendbird-uikit-ios/releases/download/3.33.1/SendBirdUIKit.zip',
+    :sha1 => '7bfb201ad6294b6812e8a4c263ce8277349a03b8'
+  }
+  s.requires_arc = true
+  s.platform = :ios, '13.0'
+  s.documentation_url = 'https://sendbird.com/docs/uikit'
+  s.ios.vendored_frameworks = 'SendBirdUIKit/SendbirdUIKit.xcframework'
+  s.dependency 'SendbirdChatSDK', '>= 4.35.0'
+  s.dependency 'SendbirdUIMessageTemplate', '>= 3.33.1'
+  s.ios.frameworks = ['UIKit', 'Foundation', 'CoreData', 'SendbirdChatSDK']
+  s.ios.library = 'icucore'
+  s.pod_target_xcconfig = { 'ENABLE_USER_SCRIPT_SANDBOXING' => 'NO' }
+  s.user_target_xcconfig = { 'ENABLE_USER_SCRIPT_SANDBOXING' => 'NO' }
+end

--- a/Specs/SendBirdUIKit/3.34.0/SendBirdUIKit.podspec
+++ b/Specs/SendBirdUIKit/3.34.0/SendBirdUIKit.podspec
@@ -1,0 +1,31 @@
+Pod::Spec.new do |s|
+  s.name = 'SendBirdUIKit'
+  s.version = '3.34.0'
+  s.summary = 'Sendbird UIKit iOS Framework'
+  s.description = 'UIKit module for Sendbird iOS SDK'
+  s.homepage = 'https://sendbird.com'
+  s.license = { :type => 'Commercial', :file => 'SendBirdUIKit/LICENSE.md' }
+  s.authors = {
+    'Sendbird' => 'sha.sdk_deployment@sendbird.com',
+    'Jed Gyeong' => 'jed.gyeong@sendbird.com',
+    'Celine Moon' => 'celine.moon@sendbird.com',
+    'Tez Park' => 'tez.park@sendbird.com',
+    'Damon Park' => 'damon.park@sendbird.com',
+    'Young Hwang' => 'young.hwang@sendbird.com',
+    'Kai Lee' => 'kai.lee@sendbird.com'
+  }
+  s.source = {
+    :http => 'https://github.com/sendbird/sendbird-uikit-ios/releases/download/3.34.0/SendBirdUIKit.zip',
+    :sha1 => 'd33c19561834f0bf4393411fd81543d4b95dc369'
+  }
+  s.requires_arc = true
+  s.platform = :ios, '13.0'
+  s.documentation_url = 'https://sendbird.com/docs/uikit'
+  s.ios.vendored_frameworks = 'SendBirdUIKit/SendbirdUIKit.xcframework'
+  s.dependency 'SendbirdChatSDK', '>= 4.35.0'
+  s.dependency 'SendbirdUIMessageTemplate', '>= 3.34.0'
+  s.ios.frameworks = ['UIKit', 'Foundation', 'CoreData', 'SendbirdChatSDK']
+  s.ios.library = 'icucore'
+  s.pod_target_xcconfig = { 'ENABLE_USER_SCRIPT_SANDBOXING' => 'NO' }
+  s.user_target_xcconfig = { 'ENABLE_USER_SCRIPT_SANDBOXING' => 'NO' }
+end

--- a/Specs/SendBirdUIKit/3.35.0/SendBirdUIKit.podspec
+++ b/Specs/SendBirdUIKit/3.35.0/SendBirdUIKit.podspec
@@ -1,0 +1,31 @@
+Pod::Spec.new do |s|
+  s.name = 'SendBirdUIKit'
+  s.version = '3.35.0'
+  s.summary = 'Sendbird UIKit iOS Framework'
+  s.description = 'UIKit module for Sendbird iOS SDK'
+  s.homepage = 'https://sendbird.com'
+  s.license = { :type => 'Commercial', :file => 'SendBirdUIKit/LICENSE.md' }
+  s.authors = {
+    'Sendbird' => 'sha.sdk_deployment@sendbird.com',
+    'Jed Gyeong' => 'jed.gyeong@sendbird.com',
+    'Celine Moon' => 'celine.moon@sendbird.com',
+    'Tez Park' => 'tez.park@sendbird.com',
+    'Damon Park' => 'damon.park@sendbird.com',
+    'Young Hwang' => 'young.hwang@sendbird.com',
+    'Kai Lee' => 'kai.lee@sendbird.com'
+  }
+  s.source = {
+    :http => 'https://github.com/sendbird/sendbird-uikit-ios/releases/download/3.35.0/SendBirdUIKit.zip',
+    :sha1 => 'e8c4d4fbd2e6c39b66b4f0e14edf161e4096c987'
+  }
+  s.requires_arc = true
+  s.platform = :ios, '13.0'
+  s.documentation_url = 'https://sendbird.com/docs/uikit'
+  s.ios.vendored_frameworks = 'SendBirdUIKit/SendbirdUIKit.xcframework'
+  s.dependency 'SendbirdChatSDK', '>= 4.39.0'
+  s.dependency 'SendbirdUIMessageTemplate', '>= 3.35.0'
+  s.ios.frameworks = ['UIKit', 'Foundation', 'CoreData', 'SendbirdChatSDK']
+  s.ios.library = 'icucore'
+  s.pod_target_xcconfig = { 'ENABLE_USER_SCRIPT_SANDBOXING' => 'NO' }
+  s.user_target_xcconfig = { 'ENABLE_USER_SCRIPT_SANDBOXING' => 'NO' }
+end

--- a/Specs/SendBirdUIKit/3.35.2/SendBirdUIKit.podspec
+++ b/Specs/SendBirdUIKit/3.35.2/SendBirdUIKit.podspec
@@ -1,0 +1,31 @@
+Pod::Spec.new do |s|
+  s.name = 'SendBirdUIKit'
+  s.version = '3.35.2'
+  s.summary = 'Sendbird UIKit iOS Framework'
+  s.description = 'UIKit module for Sendbird iOS SDK'
+  s.homepage = 'https://sendbird.com'
+  s.license = { :type => 'Commercial', :file => 'SendBirdUIKit/LICENSE.md' }
+  s.authors = {
+    'Sendbird' => 'sha.sdk_deployment@sendbird.com',
+    'Jed Gyeong' => 'jed.gyeong@sendbird.com',
+    'Celine Moon' => 'celine.moon@sendbird.com',
+    'Tez Park' => 'tez.park@sendbird.com',
+    'Damon Park' => 'damon.park@sendbird.com',
+    'Young Hwang' => 'young.hwang@sendbird.com',
+    'Kai Lee' => 'kai.lee@sendbird.com'
+  }
+  s.source = {
+    :http => 'https://github.com/sendbird/sendbird-uikit-ios/releases/download/3.35.2/SendBirdUIKit.zip',
+    :sha1 => '0b0df7cc064d46c27d8329cabf2885bf4a693331'
+  }
+  s.requires_arc = true
+  s.platform = :ios, '13.0'
+  s.documentation_url = 'https://sendbird.com/docs/uikit'
+  s.ios.vendored_frameworks = 'SendBirdUIKit/SendbirdUIKit.xcframework'
+  s.dependency 'SendbirdChatSDK', '>= 4.39.4'
+  s.dependency 'SendbirdUIMessageTemplate', '>= 3.35.2'
+  s.ios.frameworks = ['UIKit', 'Foundation', 'CoreData', 'SendbirdChatSDK']
+  s.ios.library = 'icucore'
+  s.pod_target_xcconfig = { 'ENABLE_USER_SCRIPT_SANDBOXING' => 'NO' }
+  s.user_target_xcconfig = { 'ENABLE_USER_SCRIPT_SANDBOXING' => 'NO' }
+end

--- a/Specs/SendBirdUIKit/3.35.3/SendBirdUIKit.podspec
+++ b/Specs/SendBirdUIKit/3.35.3/SendBirdUIKit.podspec
@@ -1,0 +1,31 @@
+Pod::Spec.new do |s|
+  s.name = 'SendBirdUIKit'
+  s.version = '3.35.3'
+  s.summary = 'Sendbird UIKit iOS Framework'
+  s.description = 'UIKit module for Sendbird iOS SDK'
+  s.homepage = 'https://sendbird.com'
+  s.license = { :type => 'Commercial', :file => 'SendBirdUIKit/LICENSE.md' }
+  s.authors = {
+    'Sendbird' => 'sha.sdk_deployment@sendbird.com',
+    'Jed Gyeong' => 'jed.gyeong@sendbird.com',
+    'Celine Moon' => 'celine.moon@sendbird.com',
+    'Tez Park' => 'tez.park@sendbird.com',
+    'Damon Park' => 'damon.park@sendbird.com',
+    'Young Hwang' => 'young.hwang@sendbird.com',
+    'Kai Lee' => 'kai.lee@sendbird.com'
+  }
+  s.source = {
+    :http => 'https://github.com/sendbird/sendbird-uikit-ios/releases/download/3.35.3/SendBirdUIKit.zip',
+    :sha1 => 'c9df5ab35cbcb00fbba5704eaf9119ca20b0bcf6'
+  }
+  s.requires_arc = true
+  s.platform = :ios, '13.0'
+  s.documentation_url = 'https://sendbird.com/docs/uikit'
+  s.ios.vendored_frameworks = 'SendBirdUIKit/SendbirdUIKit.xcframework'
+  s.dependency 'SendbirdChatSDK', '>= 4.39.4'
+  s.dependency 'SendbirdUIMessageTemplate', '>= 3.35.3'
+  s.ios.frameworks = ['UIKit', 'Foundation', 'CoreData', 'SendbirdChatSDK']
+  s.ios.library = 'icucore'
+  s.pod_target_xcconfig = { 'ENABLE_USER_SCRIPT_SANDBOXING' => 'NO' }
+  s.user_target_xcconfig = { 'ENABLE_USER_SCRIPT_SANDBOXING' => 'NO' }
+end

--- a/Specs/SendbirdAuthSDK/0.0.10/SendbirdAuthSDK.podspec
+++ b/Specs/SendbirdAuthSDK/0.0.10/SendbirdAuthSDK.podspec
@@ -1,0 +1,28 @@
+Pod::Spec.new do |s|
+  s.name = 'SendbirdAuthSDK'
+  s.version = '0.0.10'
+  s.summary = 'Sendbird Auth iOS Framework'
+  s.description = 'Authentication module for Sendbird iOS SDK'
+  s.homepage = 'https://sendbird.com'
+  s.license = { :type => 'Commercial', :file => 'SendbirdAuthSDK/LICENSE.md' }
+  s.authors = {
+    'Sendbird' => 'sha.sdk_deployment@sendbird.com',
+    'Jed Gyeong' => 'jed.gyeong@sendbird.com',
+    'Celine Moon' => 'celine.moon@sendbird.com',
+    'Tez Park' => 'tez.park@sendbird.com',
+    'Damon Park' => 'damon.park@sendbird.com',
+    'Young Hwang' => 'young.hwang@sendbird.com',
+    'Kai Lee' => 'kai.lee@sendbird.com'
+  }
+  s.source = {
+    :http => 'https://github.com/sendbird/sendbird-auth-ios/releases/download/0.0.10/SendbirdAuthSDK.zip',
+    :sha1 => 'fbaca18a4690b8e573c5c5c31fe97b8fd0c424a7'
+  }
+  s.requires_arc = true
+  s.ios.deployment_target = '13.0'
+  s.documentation_url = 'https://sendbird.com/docs/chat'
+  s.ios.vendored_frameworks = 'SendbirdAuthSDK/SendbirdAuthSDK.xcframework'
+  s.ios.frameworks = 'UIKit', 'CFNetwork', 'Security', 'Foundation', 'Network'
+  s.pod_target_xcconfig = { 'ENABLE_USER_SCRIPT_SANDBOXING' => 'NO' }
+  s.user_target_xcconfig = { 'ENABLE_USER_SCRIPT_SANDBOXING' => 'NO' }
+end

--- a/Specs/SendbirdAuthSDK/0.0.11/SendbirdAuthSDK.podspec
+++ b/Specs/SendbirdAuthSDK/0.0.11/SendbirdAuthSDK.podspec
@@ -1,0 +1,28 @@
+Pod::Spec.new do |s|
+  s.name = 'SendbirdAuthSDK'
+  s.version = '0.0.11'
+  s.summary = 'Sendbird Auth iOS Framework'
+  s.description = 'Authentication module for Sendbird iOS SDK'
+  s.homepage = 'https://sendbird.com'
+  s.license = { :type => 'Commercial', :file => 'SendbirdAuthSDK/LICENSE.md' }
+  s.authors = {
+    'Sendbird' => 'sha.sdk_deployment@sendbird.com',
+    'Jed Gyeong' => 'jed.gyeong@sendbird.com',
+    'Celine Moon' => 'celine.moon@sendbird.com',
+    'Tez Park' => 'tez.park@sendbird.com',
+    'Damon Park' => 'damon.park@sendbird.com',
+    'Young Hwang' => 'young.hwang@sendbird.com',
+    'Kai Lee' => 'kai.lee@sendbird.com'
+  }
+  s.source = {
+    :http => 'https://github.com/sendbird/sendbird-auth-ios/releases/download/0.0.11/SendbirdAuthSDK.zip',
+    :sha1 => 'b3a8ca531d9817c5d0f164656aebc11d20cd6452'
+  }
+  s.requires_arc = true
+  s.ios.deployment_target = '13.0'
+  s.documentation_url = 'https://sendbird.com/docs/chat'
+  s.ios.vendored_frameworks = 'SendbirdAuthSDK/SendbirdAuthSDK.xcframework'
+  s.ios.frameworks = 'UIKit', 'CFNetwork', 'Security', 'Foundation', 'Network'
+  s.pod_target_xcconfig = { 'ENABLE_USER_SCRIPT_SANDBOXING' => 'NO' }
+  s.user_target_xcconfig = { 'ENABLE_USER_SCRIPT_SANDBOXING' => 'NO' }
+end

--- a/Specs/SendbirdAuthSDK/0.0.12/SendbirdAuthSDK.podspec
+++ b/Specs/SendbirdAuthSDK/0.0.12/SendbirdAuthSDK.podspec
@@ -1,0 +1,28 @@
+Pod::Spec.new do |s|
+  s.name = 'SendbirdAuthSDK'
+  s.version = '0.0.12'
+  s.summary = 'Sendbird Auth iOS Framework'
+  s.description = 'Authentication module for Sendbird iOS SDK'
+  s.homepage = 'https://sendbird.com'
+  s.license = { :type => 'Commercial', :file => 'SendbirdAuthSDK/LICENSE.md' }
+  s.authors = {
+    'Sendbird' => 'sha.sdk_deployment@sendbird.com',
+    'Jed Gyeong' => 'jed.gyeong@sendbird.com',
+    'Celine Moon' => 'celine.moon@sendbird.com',
+    'Tez Park' => 'tez.park@sendbird.com',
+    'Damon Park' => 'damon.park@sendbird.com',
+    'Young Hwang' => 'young.hwang@sendbird.com',
+    'Kai Lee' => 'kai.lee@sendbird.com'
+  }
+  s.source = {
+    :http => 'https://github.com/sendbird/sendbird-auth-ios/releases/download/0.0.12/SendbirdAuthSDK.zip',
+    :sha1 => '9db4526ec3d32e7c56946099d002f3e2ba72c993'
+  }
+  s.requires_arc = true
+  s.ios.deployment_target = '13.0'
+  s.documentation_url = 'https://sendbird.com/docs/chat'
+  s.ios.vendored_frameworks = 'SendbirdAuthSDK/SendbirdAuthSDK.xcframework'
+  s.ios.frameworks = 'UIKit', 'CFNetwork', 'Security', 'Foundation', 'Network'
+  s.pod_target_xcconfig = { 'ENABLE_USER_SCRIPT_SANDBOXING' => 'NO' }
+  s.user_target_xcconfig = { 'ENABLE_USER_SCRIPT_SANDBOXING' => 'NO' }
+end

--- a/Specs/SendbirdAuthSDK/1.0.0/SendbirdAuthSDK.podspec
+++ b/Specs/SendbirdAuthSDK/1.0.0/SendbirdAuthSDK.podspec
@@ -1,0 +1,28 @@
+Pod::Spec.new do |s|
+  s.name = 'SendbirdAuthSDK'
+  s.version = '1.0.0'
+  s.summary = 'Sendbird Auth iOS Framework'
+  s.description = 'Authentication module for Sendbird iOS SDK'
+  s.homepage = 'https://sendbird.com'
+  s.license = { :type => 'Commercial', :file => 'SendbirdAuthSDK/LICENSE.md' }
+  s.authors = {
+    'Sendbird' => 'sha.sdk_deployment@sendbird.com',
+    'Jed Gyeong' => 'jed.gyeong@sendbird.com',
+    'Celine Moon' => 'celine.moon@sendbird.com',
+    'Tez Park' => 'tez.park@sendbird.com',
+    'Damon Park' => 'damon.park@sendbird.com',
+    'Young Hwang' => 'young.hwang@sendbird.com',
+    'Kai Lee' => 'kai.lee@sendbird.com'
+  }
+  s.source = {
+    :http => 'https://github.com/sendbird/sendbird-auth-ios/releases/download/1.0.0/SendbirdAuthSDK.zip',
+    :sha1 => '5e50a6a1ffb9e06e7eb8c73e7d83fbc944320628'
+  }
+  s.requires_arc = true
+  s.ios.deployment_target = '13.0'
+  s.documentation_url = 'https://sendbird.com/docs/chat'
+  s.ios.vendored_frameworks = 'SendbirdAuthSDK/SendbirdAuthSDK.xcframework'
+  s.ios.frameworks = 'UIKit', 'CFNetwork', 'Security', 'Foundation', 'Network'
+  s.pod_target_xcconfig = { 'ENABLE_USER_SCRIPT_SANDBOXING' => 'NO' }
+  s.user_target_xcconfig = { 'ENABLE_USER_SCRIPT_SANDBOXING' => 'NO' }
+end

--- a/Specs/SendbirdAuthSDK/1.0.1/SendbirdAuthSDK.podspec
+++ b/Specs/SendbirdAuthSDK/1.0.1/SendbirdAuthSDK.podspec
@@ -1,0 +1,28 @@
+Pod::Spec.new do |s|
+  s.name = 'SendbirdAuthSDK'
+  s.version = '1.0.1'
+  s.summary = 'Sendbird Auth iOS Framework'
+  s.description = 'Authentication module for Sendbird iOS SDK'
+  s.homepage = 'https://sendbird.com'
+  s.license = { :type => 'Commercial', :file => 'SendbirdAuthSDK/LICENSE.md' }
+  s.authors = {
+    'Sendbird' => 'sha.sdk_deployment@sendbird.com',
+    'Jed Gyeong' => 'jed.gyeong@sendbird.com',
+    'Celine Moon' => 'celine.moon@sendbird.com',
+    'Tez Park' => 'tez.park@sendbird.com',
+    'Damon Park' => 'damon.park@sendbird.com',
+    'Young Hwang' => 'young.hwang@sendbird.com',
+    'Kai Lee' => 'kai.lee@sendbird.com'
+  }
+  s.source = {
+    :http => 'https://github.com/sendbird/sendbird-auth-ios/releases/download/1.0.1/SendbirdAuthSDK.zip',
+    :sha1 => '255a79d62b46cdd4556bed3c522a0fe7f9ab1afa'
+  }
+  s.requires_arc = true
+  s.ios.deployment_target = '13.0'
+  s.documentation_url = 'https://sendbird.com/docs/chat'
+  s.ios.vendored_frameworks = 'SendbirdAuthSDK/SendbirdAuthSDK.xcframework'
+  s.ios.frameworks = 'UIKit', 'CFNetwork', 'Security', 'Foundation', 'Network'
+  s.pod_target_xcconfig = { 'ENABLE_USER_SCRIPT_SANDBOXING' => 'NO' }
+  s.user_target_xcconfig = { 'ENABLE_USER_SCRIPT_SANDBOXING' => 'NO' }
+end

--- a/Specs/SendbirdAuthSDK/1.1.0/SendbirdAuthSDK.podspec
+++ b/Specs/SendbirdAuthSDK/1.1.0/SendbirdAuthSDK.podspec
@@ -1,0 +1,28 @@
+Pod::Spec.new do |s|
+  s.name = 'SendbirdAuthSDK'
+  s.version = '1.1.0'
+  s.summary = 'Sendbird Auth iOS Framework'
+  s.description = 'Authentication module for Sendbird iOS SDK'
+  s.homepage = 'https://sendbird.com'
+  s.license = { :type => 'Commercial', :file => 'SendbirdAuthSDK/LICENSE.md' }
+  s.authors = {
+    'Sendbird' => 'sha.sdk_deployment@sendbird.com',
+    'Jed Gyeong' => 'jed.gyeong@sendbird.com',
+    'Celine Moon' => 'celine.moon@sendbird.com',
+    'Tez Park' => 'tez.park@sendbird.com',
+    'Damon Park' => 'damon.park@sendbird.com',
+    'Young Hwang' => 'young.hwang@sendbird.com',
+    'Kai Lee' => 'kai.lee@sendbird.com'
+  }
+  s.source = {
+    :http => 'https://github.com/sendbird/sendbird-auth-ios/releases/download/1.1.0/SendbirdAuthSDK.zip',
+    :sha1 => '2365122cfa84994c6c238ccdb33448a422993237'
+  }
+  s.requires_arc = true
+  s.ios.deployment_target = '13.0'
+  s.documentation_url = 'https://sendbird.com/docs/chat'
+  s.ios.vendored_frameworks = 'SendbirdAuthSDK/SendbirdAuthSDK.xcframework'
+  s.ios.frameworks = 'UIKit', 'CFNetwork', 'Security', 'Foundation', 'Network'
+  s.pod_target_xcconfig = { 'ENABLE_USER_SCRIPT_SANDBOXING' => 'NO' }
+  s.user_target_xcconfig = { 'ENABLE_USER_SCRIPT_SANDBOXING' => 'NO' }
+end

--- a/Specs/SendbirdAuthSDK/1.1.1/SendbirdAuthSDK.podspec
+++ b/Specs/SendbirdAuthSDK/1.1.1/SendbirdAuthSDK.podspec
@@ -1,0 +1,28 @@
+Pod::Spec.new do |s|
+  s.name = 'SendbirdAuthSDK'
+  s.version = '1.1.1'
+  s.summary = 'Sendbird Auth iOS Framework'
+  s.description = 'Authentication module for Sendbird iOS SDK'
+  s.homepage = 'https://sendbird.com'
+  s.license = { :type => 'Commercial', :file => 'SendbirdAuthSDK/LICENSE.md' }
+  s.authors = {
+    'Sendbird' => 'sha.sdk_deployment@sendbird.com',
+    'Jed Gyeong' => 'jed.gyeong@sendbird.com',
+    'Celine Moon' => 'celine.moon@sendbird.com',
+    'Tez Park' => 'tez.park@sendbird.com',
+    'Damon Park' => 'damon.park@sendbird.com',
+    'Young Hwang' => 'young.hwang@sendbird.com',
+    'Kai Lee' => 'kai.lee@sendbird.com'
+  }
+  s.source = {
+    :http => 'https://github.com/sendbird/sendbird-auth-ios/releases/download/1.1.1/SendbirdAuthSDK.zip',
+    :sha1 => '724966d1c8c61a43f9a9bd0eb34baa40d9836fcd'
+  }
+  s.requires_arc = true
+  s.ios.deployment_target = '13.0'
+  s.documentation_url = 'https://sendbird.com/docs/chat'
+  s.ios.vendored_frameworks = 'SendbirdAuthSDK/SendbirdAuthSDK.xcframework'
+  s.ios.frameworks = 'UIKit', 'CFNetwork', 'Security', 'Foundation', 'Network'
+  s.pod_target_xcconfig = { 'ENABLE_USER_SCRIPT_SANDBOXING' => 'NO' }
+  s.user_target_xcconfig = { 'ENABLE_USER_SCRIPT_SANDBOXING' => 'NO' }
+end

--- a/Specs/SendbirdAuthSDK/1.1.3/SendbirdAuthSDK.podspec
+++ b/Specs/SendbirdAuthSDK/1.1.3/SendbirdAuthSDK.podspec
@@ -1,0 +1,28 @@
+Pod::Spec.new do |s|
+  s.name = 'SendbirdAuthSDK'
+  s.version = '1.1.3'
+  s.summary = 'Sendbird Auth iOS Framework'
+  s.description = 'Authentication module for Sendbird iOS SDK'
+  s.homepage = 'https://sendbird.com'
+  s.license = { :type => 'Commercial', :file => 'SendbirdAuthSDK/LICENSE.md' }
+  s.authors = {
+    'Sendbird' => 'sha.sdk_deployment@sendbird.com',
+    'Jed Gyeong' => 'jed.gyeong@sendbird.com',
+    'Celine Moon' => 'celine.moon@sendbird.com',
+    'Tez Park' => 'tez.park@sendbird.com',
+    'Damon Park' => 'damon.park@sendbird.com',
+    'Young Hwang' => 'young.hwang@sendbird.com',
+    'Kai Lee' => 'kai.lee@sendbird.com'
+  }
+  s.source = {
+    :http => 'https://github.com/sendbird/sendbird-auth-ios/releases/download/1.1.3/SendbirdAuthSDK.zip',
+    :sha1 => 'fdb60a93323f250f2538b8eeb2b839e9413163ae'
+  }
+  s.requires_arc = true
+  s.ios.deployment_target = '13.0'
+  s.documentation_url = 'https://sendbird.com/docs/chat'
+  s.ios.vendored_frameworks = 'SendbirdAuthSDK/SendbirdAuthSDK.xcframework'
+  s.ios.frameworks = 'UIKit', 'CFNetwork', 'Security', 'Foundation', 'Network'
+  s.pod_target_xcconfig = { 'ENABLE_USER_SCRIPT_SANDBOXING' => 'NO' }
+  s.user_target_xcconfig = { 'ENABLE_USER_SCRIPT_SANDBOXING' => 'NO' }
+end

--- a/Specs/SendbirdChatSDK/4.37.2/SendbirdChatSDK.podspec
+++ b/Specs/SendbirdChatSDK/4.37.2/SendbirdChatSDK.podspec
@@ -1,0 +1,32 @@
+
+Pod::Spec.new do |s|
+  s.name         = 'SendbirdChatSDK'
+  s.version      = "4.37.2"
+  s.summary      = 'Sendbird Chat iOS Framework'
+  s.description  = 'Messaging and Chat API for Mobile Apps and Websites'
+  s.homepage     = 'https://sendbird.com'
+  s.license      = { :type => 'Commercial', :file => 'SendbirdChatSDK/LICENSE.md' }
+  s.authors = {
+    'Sendbird' => 'sha.sdk_deployment@sendbird.com',
+    'Jed Gyeong' => 'jed.gyeong@sendbird.com',
+    'Celine Moon' => 'celine.moon@sendbird.com',
+    'Tez Park' => 'tez.park@sendbird.com',
+    'Damon Park' => 'damon.park@sendbird.com',
+    'Young Hwang' => 'young.hwang@sendbird.com',
+    'Kai Lee' => 'kai.lee@sendbird.com'
+  }
+  s.source       = { :http => "https://github.com/sendbird/sendbird-chat-sdk-ios/releases/download/4.37.2/SendbirdChatSDK.zip", :sha1 => "25c12efae1d5207f72e160356855a3100d3b69ed" }
+  s.requires_arc = true
+  s.platform = :ios, '13.0'
+  s.documentation_url = 'https://sendbird.com/docs/chat'
+  s.ios.vendored_frameworks = 'SendbirdChatSDK/SendbirdChatSDK.xcframework'
+  s.dependency 'SendbirdAuthSDK', '0.0.12'
+  s.pod_target_xcconfig = {
+    'ENABLE_USER_SCRIPT_SANDBOXING' => 'NO'
+  }
+  s.user_target_xcconfig = {
+    'ENABLE_USER_SCRIPT_SANDBOXING' => 'NO'
+  }
+  s.ios.frameworks = ['UIKit', 'CFNetwork', 'Security', 'Foundation', 'Network', 'MobileCoreServices', 'SystemConfiguration', 'CoreFoundation']
+  s.ios.library   = 'icucore'
+end

--- a/Specs/SendbirdChatSDK/4.38.0/SendbirdChatSDK.podspec
+++ b/Specs/SendbirdChatSDK/4.38.0/SendbirdChatSDK.podspec
@@ -1,0 +1,32 @@
+
+Pod::Spec.new do |s|
+  s.name         = 'SendbirdChatSDK'
+  s.version      = "4.38.0"
+  s.summary      = 'Sendbird Chat iOS Framework'
+  s.description  = 'Messaging and Chat API for Mobile Apps and Websites'
+  s.homepage     = 'https://sendbird.com'
+  s.license      = { :type => 'Commercial', :file => 'SendbirdChatSDK/LICENSE.md' }
+  s.authors = {
+    'Sendbird' => 'sha.sdk_deployment@sendbird.com',
+    'Jed Gyeong' => 'jed.gyeong@sendbird.com',
+    'Celine Moon' => 'celine.moon@sendbird.com',
+    'Tez Park' => 'tez.park@sendbird.com',
+    'Damon Park' => 'damon.park@sendbird.com',
+    'Young Hwang' => 'young.hwang@sendbird.com',
+    'Kai Lee' => 'kai.lee@sendbird.com'
+  }
+  s.source       = { :http => "https://github.com/sendbird/sendbird-chat-sdk-ios/releases/download/4.38.0/SendbirdChatSDK.zip", :sha1 => "9f772202921549f94c6684c6fb462e0f60f71c57" }
+  s.requires_arc = true
+  s.platform = :ios, '13.0'
+  s.documentation_url = 'https://sendbird.com/docs/chat'
+  s.ios.vendored_frameworks = 'SendbirdChatSDK/SendbirdChatSDK.xcframework'
+  s.dependency 'SendbirdAuthSDK', '1.0.0'
+  s.pod_target_xcconfig = {
+    'ENABLE_USER_SCRIPT_SANDBOXING' => 'NO'
+  }
+  s.user_target_xcconfig = {
+    'ENABLE_USER_SCRIPT_SANDBOXING' => 'NO'
+  }
+  s.ios.frameworks = ['UIKit', 'CFNetwork', 'Security', 'Foundation', 'Network', 'MobileCoreServices', 'SystemConfiguration', 'CoreFoundation']
+  s.ios.library   = 'icucore'
+end

--- a/Specs/SendbirdChatSDK/4.38.1/SendbirdChatSDK.podspec
+++ b/Specs/SendbirdChatSDK/4.38.1/SendbirdChatSDK.podspec
@@ -1,0 +1,32 @@
+
+Pod::Spec.new do |s|
+  s.name         = 'SendbirdChatSDK'
+  s.version      = "4.38.1"
+  s.summary      = 'Sendbird Chat iOS Framework'
+  s.description  = 'Messaging and Chat API for Mobile Apps and Websites'
+  s.homepage     = 'https://sendbird.com'
+  s.license      = { :type => 'Commercial', :file => 'SendbirdChatSDK/LICENSE.md' }
+  s.authors = {
+    'Sendbird' => 'sha.sdk_deployment@sendbird.com',
+    'Jed Gyeong' => 'jed.gyeong@sendbird.com',
+    'Celine Moon' => 'celine.moon@sendbird.com',
+    'Tez Park' => 'tez.park@sendbird.com',
+    'Damon Park' => 'damon.park@sendbird.com',
+    'Young Hwang' => 'young.hwang@sendbird.com',
+    'Kai Lee' => 'kai.lee@sendbird.com'
+  }
+  s.source       = { :http => "https://github.com/sendbird/sendbird-chat-sdk-ios/releases/download/4.38.1/SendbirdChatSDK.zip", :sha1 => "b0a653e670b1e3c41cc37b191dcc61fefd311193" }
+  s.requires_arc = true
+  s.platform = :ios, '13.0'
+  s.documentation_url = 'https://sendbird.com/docs/chat'
+  s.ios.vendored_frameworks = 'SendbirdChatSDK/SendbirdChatSDK.xcframework'
+  s.dependency 'SendbirdAuthSDK', '1.0.1'
+  s.pod_target_xcconfig = {
+    'ENABLE_USER_SCRIPT_SANDBOXING' => 'NO'
+  }
+  s.user_target_xcconfig = {
+    'ENABLE_USER_SCRIPT_SANDBOXING' => 'NO'
+  }
+  s.ios.frameworks = ['UIKit', 'CFNetwork', 'Security', 'Foundation', 'Network', 'MobileCoreServices', 'SystemConfiguration', 'CoreFoundation']
+  s.ios.library   = 'icucore'
+end

--- a/Specs/SendbirdChatSDK/4.39.0/SendbirdChatSDK.podspec
+++ b/Specs/SendbirdChatSDK/4.39.0/SendbirdChatSDK.podspec
@@ -1,0 +1,32 @@
+
+Pod::Spec.new do |s|
+  s.name         = 'SendbirdChatSDK'
+  s.version      = "4.39.0"
+  s.summary      = 'Sendbird Chat iOS Framework'
+  s.description  = 'Messaging and Chat API for Mobile Apps and Websites'
+  s.homepage     = 'https://sendbird.com'
+  s.license      = { :type => 'Commercial', :file => 'SendbirdChatSDK/LICENSE.md' }
+  s.authors = {
+    'Sendbird' => 'sha.sdk_deployment@sendbird.com',
+    'Jed Gyeong' => 'jed.gyeong@sendbird.com',
+    'Celine Moon' => 'celine.moon@sendbird.com',
+    'Tez Park' => 'tez.park@sendbird.com',
+    'Damon Park' => 'damon.park@sendbird.com',
+    'Young Hwang' => 'young.hwang@sendbird.com',
+    'Kai Lee' => 'kai.lee@sendbird.com'
+  }
+  s.source       = { :http => "https://github.com/sendbird/sendbird-chat-sdk-ios/releases/download/4.39.0/SendbirdChatSDK.zip", :sha1 => "a49db7a8ed09261d99856a225216a5355849f186" }
+  s.requires_arc = true
+  s.platform = :ios, '13.0'
+  s.documentation_url = 'https://sendbird.com/docs/chat'
+  s.ios.vendored_frameworks = 'SendbirdChatSDK/SendbirdChatSDK.xcframework'
+  s.dependency 'SendbirdAuthSDK', '1.1.0'
+  s.pod_target_xcconfig = {
+    'ENABLE_USER_SCRIPT_SANDBOXING' => 'NO'
+  }
+  s.user_target_xcconfig = {
+    'ENABLE_USER_SCRIPT_SANDBOXING' => 'NO'
+  }
+  s.ios.frameworks = ['UIKit', 'CFNetwork', 'Security', 'Foundation', 'Network', 'MobileCoreServices', 'SystemConfiguration', 'CoreFoundation']
+  s.ios.library   = 'icucore'
+end

--- a/Specs/SendbirdChatSDK/4.39.1/SendbirdChatSDK.podspec
+++ b/Specs/SendbirdChatSDK/4.39.1/SendbirdChatSDK.podspec
@@ -1,0 +1,32 @@
+
+Pod::Spec.new do |s|
+  s.name         = 'SendbirdChatSDK'
+  s.version      = "4.39.1"
+  s.summary      = 'Sendbird Chat iOS Framework'
+  s.description  = 'Messaging and Chat API for Mobile Apps and Websites'
+  s.homepage     = 'https://sendbird.com'
+  s.license      = { :type => 'Commercial', :file => 'SendbirdChatSDK/LICENSE.md' }
+  s.authors = {
+    'Sendbird' => 'sha.sdk_deployment@sendbird.com',
+    'Jed Gyeong' => 'jed.gyeong@sendbird.com',
+    'Celine Moon' => 'celine.moon@sendbird.com',
+    'Tez Park' => 'tez.park@sendbird.com',
+    'Damon Park' => 'damon.park@sendbird.com',
+    'Young Hwang' => 'young.hwang@sendbird.com',
+    'Kai Lee' => 'kai.lee@sendbird.com'
+  }
+  s.source       = { :http => "https://github.com/sendbird/sendbird-chat-sdk-ios/releases/download/4.39.1/SendbirdChatSDK.zip", :sha1 => "ae3cf6dc839384d43f5e53c89c6af68202099c0a" }
+  s.requires_arc = true
+  s.platform = :ios, '13.0'
+  s.documentation_url = 'https://sendbird.com/docs/chat'
+  s.ios.vendored_frameworks = 'SendbirdChatSDK/SendbirdChatSDK.xcframework'
+  s.dependency 'SendbirdAuthSDK', '1.1.0'
+  s.pod_target_xcconfig = {
+    'ENABLE_USER_SCRIPT_SANDBOXING' => 'NO'
+  }
+  s.user_target_xcconfig = {
+    'ENABLE_USER_SCRIPT_SANDBOXING' => 'NO'
+  }
+  s.ios.frameworks = ['UIKit', 'CFNetwork', 'Security', 'Foundation', 'Network', 'MobileCoreServices', 'SystemConfiguration', 'CoreFoundation']
+  s.ios.library   = 'icucore'
+end

--- a/Specs/SendbirdChatSDK/4.39.2/SendbirdChatSDK.podspec
+++ b/Specs/SendbirdChatSDK/4.39.2/SendbirdChatSDK.podspec
@@ -1,0 +1,32 @@
+
+Pod::Spec.new do |s|
+  s.name         = 'SendbirdChatSDK'
+  s.version      = "4.39.2"
+  s.summary      = 'Sendbird Chat iOS Framework'
+  s.description  = 'Messaging and Chat API for Mobile Apps and Websites'
+  s.homepage     = 'https://sendbird.com'
+  s.license      = { :type => 'Commercial', :file => 'SendbirdChatSDK/LICENSE.md' }
+  s.authors = {
+    'Sendbird' => 'sha.sdk_deployment@sendbird.com',
+    'Jed Gyeong' => 'jed.gyeong@sendbird.com',
+    'Celine Moon' => 'celine.moon@sendbird.com',
+    'Tez Park' => 'tez.park@sendbird.com',
+    'Damon Park' => 'damon.park@sendbird.com',
+    'Young Hwang' => 'young.hwang@sendbird.com',
+    'Kai Lee' => 'kai.lee@sendbird.com'
+  }
+  s.source       = { :http => "https://github.com/sendbird/sendbird-chat-sdk-ios/releases/download/4.39.2/SendbirdChatSDK.zip", :sha1 => "47010d4f1559ec78e91b237065f5fd9c9e4ef88e" }
+  s.requires_arc = true
+  s.platform = :ios, '13.0'
+  s.documentation_url = 'https://sendbird.com/docs/chat'
+  s.ios.vendored_frameworks = 'SendbirdChatSDK/SendbirdChatSDK.xcframework'
+  s.dependency 'SendbirdAuthSDK', '1.1.1'
+  s.pod_target_xcconfig = {
+    'ENABLE_USER_SCRIPT_SANDBOXING' => 'NO'
+  }
+  s.user_target_xcconfig = {
+    'ENABLE_USER_SCRIPT_SANDBOXING' => 'NO'
+  }
+  s.ios.frameworks = ['UIKit', 'CFNetwork', 'Security', 'Foundation', 'Network', 'MobileCoreServices', 'SystemConfiguration', 'CoreFoundation']
+  s.ios.library   = 'icucore'
+end

--- a/Specs/SendbirdChatSDK/4.39.3/SendbirdChatSDK.podspec
+++ b/Specs/SendbirdChatSDK/4.39.3/SendbirdChatSDK.podspec
@@ -1,0 +1,32 @@
+
+Pod::Spec.new do |s|
+  s.name         = 'SendbirdChatSDK'
+  s.version      = "4.39.3"
+  s.summary      = 'Sendbird Chat iOS Framework'
+  s.description  = 'Messaging and Chat API for Mobile Apps and Websites'
+  s.homepage     = 'https://sendbird.com'
+  s.license      = { :type => 'Commercial', :file => 'SendbirdChatSDK/LICENSE.md' }
+  s.authors = {
+    'Sendbird' => 'sha.sdk_deployment@sendbird.com',
+    'Jed Gyeong' => 'jed.gyeong@sendbird.com',
+    'Celine Moon' => 'celine.moon@sendbird.com',
+    'Tez Park' => 'tez.park@sendbird.com',
+    'Damon Park' => 'damon.park@sendbird.com',
+    'Young Hwang' => 'young.hwang@sendbird.com',
+    'Kai Lee' => 'kai.lee@sendbird.com'
+  }
+  s.source       = { :http => "https://github.com/sendbird/sendbird-chat-sdk-ios/releases/download/4.39.3/SendbirdChatSDK.zip", :sha1 => "4fc9f4537480a94b8e6e49b6f26b62d354e15faf" }
+  s.requires_arc = true
+  s.platform = :ios, '13.0'
+  s.documentation_url = 'https://sendbird.com/docs/chat'
+  s.ios.vendored_frameworks = 'SendbirdChatSDK/SendbirdChatSDK.xcframework'
+  s.dependency 'SendbirdAuthSDK', '1.1.1'
+  s.pod_target_xcconfig = {
+    'ENABLE_USER_SCRIPT_SANDBOXING' => 'NO'
+  }
+  s.user_target_xcconfig = {
+    'ENABLE_USER_SCRIPT_SANDBOXING' => 'NO'
+  }
+  s.ios.frameworks = ['UIKit', 'CFNetwork', 'Security', 'Foundation', 'Network', 'MobileCoreServices', 'SystemConfiguration', 'CoreFoundation']
+  s.ios.library   = 'icucore'
+end

--- a/Specs/SendbirdChatSDK/4.39.4/SendbirdChatSDK.podspec
+++ b/Specs/SendbirdChatSDK/4.39.4/SendbirdChatSDK.podspec
@@ -1,0 +1,32 @@
+
+Pod::Spec.new do |s|
+  s.name         = 'SendbirdChatSDK'
+  s.version      = "4.39.4"
+  s.summary      = 'Sendbird Chat iOS Framework'
+  s.description  = 'Messaging and Chat API for Mobile Apps and Websites'
+  s.homepage     = 'https://sendbird.com'
+  s.license      = { :type => 'Commercial', :file => 'SendbirdChatSDK/LICENSE.md' }
+  s.authors = {
+    'Sendbird' => 'sha.sdk_deployment@sendbird.com',
+    'Jed Gyeong' => 'jed.gyeong@sendbird.com',
+    'Celine Moon' => 'celine.moon@sendbird.com',
+    'Tez Park' => 'tez.park@sendbird.com',
+    'Damon Park' => 'damon.park@sendbird.com',
+    'Young Hwang' => 'young.hwang@sendbird.com',
+    'Kai Lee' => 'kai.lee@sendbird.com'
+  }
+  s.source       = { :http => "https://github.com/sendbird/sendbird-chat-sdk-ios/releases/download/4.39.4/SendbirdChatSDK.zip", :sha1 => "e4f0207d460f7796c8dd63f4695a4a30279473ad" }
+  s.requires_arc = true
+  s.platform = :ios, '13.0'
+  s.documentation_url = 'https://sendbird.com/docs/chat'
+  s.ios.vendored_frameworks = 'SendbirdChatSDK/SendbirdChatSDK.xcframework'
+  s.dependency 'SendbirdAuthSDK', '1.1.2'
+  s.pod_target_xcconfig = {
+    'ENABLE_USER_SCRIPT_SANDBOXING' => 'NO'
+  }
+  s.user_target_xcconfig = {
+    'ENABLE_USER_SCRIPT_SANDBOXING' => 'NO'
+  }
+  s.ios.frameworks = ['UIKit', 'CFNetwork', 'Security', 'Foundation', 'Network', 'MobileCoreServices', 'SystemConfiguration', 'CoreFoundation']
+  s.ios.library   = 'icucore'
+end

--- a/Specs/SendbirdUIMessageTemplate/3.32.3/SendbirdUIMessageTemplate.podspec
+++ b/Specs/SendbirdUIMessageTemplate/3.32.3/SendbirdUIMessageTemplate.podspec
@@ -1,0 +1,30 @@
+Pod::Spec.new do |s|
+  s.name = 'SendbirdUIMessageTemplate'
+  s.version = '3.32.3'
+  s.summary = 'Sendbird UIMessageTemplate iOS Framework'
+  s.description = 'Message template UI module for Sendbird iOS SDK'
+  s.homepage = 'https://sendbird.com'
+  s.license = { :type => 'Commercial', :file => 'SendbirdUIMessageTemplate/LICENSE.md' }
+  s.authors = {
+    'Sendbird' => 'sha.sdk_deployment@sendbird.com',
+    'Jed Gyeong' => 'jed.gyeong@sendbird.com',
+    'Celine Moon' => 'celine.moon@sendbird.com',
+    'Tez Park' => 'tez.park@sendbird.com',
+    'Damon Park' => 'damon.park@sendbird.com',
+    'Young Hwang' => 'young.hwang@sendbird.com',
+    'Kai Lee' => 'kai.lee@sendbird.com'
+  }
+  s.source = {
+    :http => 'https://github.com/sendbird/sendbird-uikit-ios/releases/download/3.32.3/SendbirdUIMessageTemplate.zip',
+    :sha1 => '0e506ad26514d6b238ab44846d9154c02bf98da2'
+  }
+  s.requires_arc = true
+  s.platform = :ios, '13.0'
+  s.documentation_url = 'https://sendbird.com/docs/uikit'
+  s.ios.vendored_frameworks = 'SendbirdUIMessageTemplate/SendbirdUIMessageTemplate.xcframework'
+  s.dependency 'SendbirdChatSDK', '>= 4.31.1'
+  s.ios.frameworks = ['UIKit', 'Foundation', 'CoreData', 'SendbirdChatSDK']
+  s.ios.library = 'icucore'
+  s.pod_target_xcconfig = { 'ENABLE_USER_SCRIPT_SANDBOXING' => 'NO' }
+  s.user_target_xcconfig = { 'ENABLE_USER_SCRIPT_SANDBOXING' => 'NO' }
+end

--- a/Specs/SendbirdUIMessageTemplate/3.32.4/SendbirdUIMessageTemplate.podspec
+++ b/Specs/SendbirdUIMessageTemplate/3.32.4/SendbirdUIMessageTemplate.podspec
@@ -1,0 +1,30 @@
+Pod::Spec.new do |s|
+  s.name = 'SendbirdUIMessageTemplate'
+  s.version = '3.32.4'
+  s.summary = 'Sendbird UIMessageTemplate iOS Framework'
+  s.description = 'Message template UI module for Sendbird iOS SDK'
+  s.homepage = 'https://sendbird.com'
+  s.license = { :type => 'Commercial', :file => 'SendbirdUIMessageTemplate/LICENSE.md' }
+  s.authors = {
+    'Sendbird' => 'sha.sdk_deployment@sendbird.com',
+    'Jed Gyeong' => 'jed.gyeong@sendbird.com',
+    'Celine Moon' => 'celine.moon@sendbird.com',
+    'Tez Park' => 'tez.park@sendbird.com',
+    'Damon Park' => 'damon.park@sendbird.com',
+    'Young Hwang' => 'young.hwang@sendbird.com',
+    'Kai Lee' => 'kai.lee@sendbird.com'
+  }
+  s.source = {
+    :http => 'https://github.com/sendbird/sendbird-uikit-ios/releases/download/3.32.4/SendbirdUIMessageTemplate.zip',
+    :sha1 => '4bed46771babf5b439c897265bac6d8ef03f7102'
+  }
+  s.requires_arc = true
+  s.platform = :ios, '13.0'
+  s.documentation_url = 'https://sendbird.com/docs/uikit'
+  s.ios.vendored_frameworks = 'SendbirdUIMessageTemplate/SendbirdUIMessageTemplate.xcframework'
+  s.dependency 'SendbirdChatSDK', '>= 4.34.1'
+  s.ios.frameworks = ['UIKit', 'Foundation', 'CoreData', 'SendbirdChatSDK']
+  s.ios.library = 'icucore'
+  s.pod_target_xcconfig = { 'ENABLE_USER_SCRIPT_SANDBOXING' => 'NO' }
+  s.user_target_xcconfig = { 'ENABLE_USER_SCRIPT_SANDBOXING' => 'NO' }
+end

--- a/Specs/SendbirdUIMessageTemplate/3.33.0/SendbirdUIMessageTemplate.podspec
+++ b/Specs/SendbirdUIMessageTemplate/3.33.0/SendbirdUIMessageTemplate.podspec
@@ -1,0 +1,30 @@
+Pod::Spec.new do |s|
+  s.name = 'SendbirdUIMessageTemplate'
+  s.version = '3.33.0'
+  s.summary = 'Sendbird UIMessageTemplate iOS Framework'
+  s.description = 'Message template UI module for Sendbird iOS SDK'
+  s.homepage = 'https://sendbird.com'
+  s.license = { :type => 'Commercial', :file => 'SendbirdUIMessageTemplate/LICENSE.md' }
+  s.authors = {
+    'Sendbird' => 'sha.sdk_deployment@sendbird.com',
+    'Jed Gyeong' => 'jed.gyeong@sendbird.com',
+    'Celine Moon' => 'celine.moon@sendbird.com',
+    'Tez Park' => 'tez.park@sendbird.com',
+    'Damon Park' => 'damon.park@sendbird.com',
+    'Young Hwang' => 'young.hwang@sendbird.com',
+    'Kai Lee' => 'kai.lee@sendbird.com'
+  }
+  s.source = {
+    :http => 'https://github.com/sendbird/sendbird-uikit-ios/releases/download/3.33.0/SendbirdUIMessageTemplate.zip',
+    :sha1 => '51eedf6e25f0599c73790a9d3e3981dcd571acd5'
+  }
+  s.requires_arc = true
+  s.platform = :ios, '13.0'
+  s.documentation_url = 'https://sendbird.com/docs/uikit'
+  s.ios.vendored_frameworks = 'SendbirdUIMessageTemplate/SendbirdUIMessageTemplate.xcframework'
+  s.dependency 'SendbirdChatSDK', '>= 4.35.0'
+  s.ios.frameworks = ['UIKit', 'Foundation', 'CoreData', 'SendbirdChatSDK']
+  s.ios.library = 'icucore'
+  s.pod_target_xcconfig = { 'ENABLE_USER_SCRIPT_SANDBOXING' => 'NO' }
+  s.user_target_xcconfig = { 'ENABLE_USER_SCRIPT_SANDBOXING' => 'NO' }
+end

--- a/Specs/SendbirdUIMessageTemplate/3.33.1/SendbirdUIMessageTemplate.podspec
+++ b/Specs/SendbirdUIMessageTemplate/3.33.1/SendbirdUIMessageTemplate.podspec
@@ -1,0 +1,30 @@
+Pod::Spec.new do |s|
+  s.name = 'SendbirdUIMessageTemplate'
+  s.version = '3.33.1'
+  s.summary = 'Sendbird UIMessageTemplate iOS Framework'
+  s.description = 'Message template UI module for Sendbird iOS SDK'
+  s.homepage = 'https://sendbird.com'
+  s.license = { :type => 'Commercial', :file => 'SendbirdUIMessageTemplate/LICENSE.md' }
+  s.authors = {
+    'Sendbird' => 'sha.sdk_deployment@sendbird.com',
+    'Jed Gyeong' => 'jed.gyeong@sendbird.com',
+    'Celine Moon' => 'celine.moon@sendbird.com',
+    'Tez Park' => 'tez.park@sendbird.com',
+    'Damon Park' => 'damon.park@sendbird.com',
+    'Young Hwang' => 'young.hwang@sendbird.com',
+    'Kai Lee' => 'kai.lee@sendbird.com'
+  }
+  s.source = {
+    :http => 'https://github.com/sendbird/sendbird-uikit-ios/releases/download/3.33.1/SendbirdUIMessageTemplate.zip',
+    :sha1 => 'f6398d8d0659c56e2e3d234cea4d335a762ca296'
+  }
+  s.requires_arc = true
+  s.platform = :ios, '13.0'
+  s.documentation_url = 'https://sendbird.com/docs/uikit'
+  s.ios.vendored_frameworks = 'SendbirdUIMessageTemplate/SendbirdUIMessageTemplate.xcframework'
+  s.dependency 'SendbirdChatSDK', '>= 4.35.0'
+  s.ios.frameworks = ['UIKit', 'Foundation', 'CoreData', 'SendbirdChatSDK']
+  s.ios.library = 'icucore'
+  s.pod_target_xcconfig = { 'ENABLE_USER_SCRIPT_SANDBOXING' => 'NO' }
+  s.user_target_xcconfig = { 'ENABLE_USER_SCRIPT_SANDBOXING' => 'NO' }
+end

--- a/Specs/SendbirdUIMessageTemplate/3.34.0/SendbirdUIMessageTemplate.podspec
+++ b/Specs/SendbirdUIMessageTemplate/3.34.0/SendbirdUIMessageTemplate.podspec
@@ -1,0 +1,30 @@
+Pod::Spec.new do |s|
+  s.name = 'SendbirdUIMessageTemplate'
+  s.version = '3.34.0'
+  s.summary = 'Sendbird UIMessageTemplate iOS Framework'
+  s.description = 'Message template UI module for Sendbird iOS SDK'
+  s.homepage = 'https://sendbird.com'
+  s.license = { :type => 'Commercial', :file => 'SendbirdUIMessageTemplate/LICENSE.md' }
+  s.authors = {
+    'Sendbird' => 'sha.sdk_deployment@sendbird.com',
+    'Jed Gyeong' => 'jed.gyeong@sendbird.com',
+    'Celine Moon' => 'celine.moon@sendbird.com',
+    'Tez Park' => 'tez.park@sendbird.com',
+    'Damon Park' => 'damon.park@sendbird.com',
+    'Young Hwang' => 'young.hwang@sendbird.com',
+    'Kai Lee' => 'kai.lee@sendbird.com'
+  }
+  s.source = {
+    :http => 'https://github.com/sendbird/sendbird-uikit-ios/releases/download/3.34.0/SendbirdUIMessageTemplate.zip',
+    :sha1 => '7d11e4c4b8f1dd64d210e13702d3dca6f7231db0'
+  }
+  s.requires_arc = true
+  s.platform = :ios, '13.0'
+  s.documentation_url = 'https://sendbird.com/docs/uikit'
+  s.ios.vendored_frameworks = 'SendbirdUIMessageTemplate/SendbirdUIMessageTemplate.xcframework'
+  s.dependency 'SendbirdChatSDK', '>= 4.35.0'
+  s.ios.frameworks = ['UIKit', 'Foundation', 'CoreData', 'SendbirdChatSDK']
+  s.ios.library = 'icucore'
+  s.pod_target_xcconfig = { 'ENABLE_USER_SCRIPT_SANDBOXING' => 'NO' }
+  s.user_target_xcconfig = { 'ENABLE_USER_SCRIPT_SANDBOXING' => 'NO' }
+end

--- a/Specs/SendbirdUIMessageTemplate/3.34.1/SendbirdUIMessageTemplate.podspec
+++ b/Specs/SendbirdUIMessageTemplate/3.34.1/SendbirdUIMessageTemplate.podspec
@@ -1,0 +1,30 @@
+Pod::Spec.new do |s|
+  s.name = 'SendbirdUIMessageTemplate'
+  s.version = '3.34.1'
+  s.summary = 'Sendbird UIMessageTemplate iOS Framework'
+  s.description = 'Message template UI module for Sendbird iOS SDK'
+  s.homepage = 'https://sendbird.com'
+  s.license = { :type => 'Commercial', :file => 'SendbirdUIMessageTemplate/LICENSE.md' }
+  s.authors = {
+    'Sendbird' => 'sha.sdk_deployment@sendbird.com',
+    'Jed Gyeong' => 'jed.gyeong@sendbird.com',
+    'Celine Moon' => 'celine.moon@sendbird.com',
+    'Tez Park' => 'tez.park@sendbird.com',
+    'Damon Park' => 'damon.park@sendbird.com',
+    'Young Hwang' => 'young.hwang@sendbird.com',
+    'Kai Lee' => 'kai.lee@sendbird.com'
+  }
+  s.source = {
+    :http => 'https://github.com/sendbird/sendbird-uikit-ios/releases/download/3.34.1/SendbirdUIMessageTemplate.zip',
+    :sha1 => 'c7c6ba105f1af564524718206d51dbe84217fd45'
+  }
+  s.requires_arc = true
+  s.platform = :ios, '13.0'
+  s.documentation_url = 'https://sendbird.com/docs/uikit'
+  s.ios.vendored_frameworks = 'SendbirdUIMessageTemplate/SendbirdUIMessageTemplate.xcframework'
+  s.dependency 'SendbirdChatSDK', '>= 4.38.2'
+  s.ios.frameworks = ['UIKit', 'Foundation', 'CoreData', 'SendbirdChatSDK']
+  s.ios.library = 'icucore'
+  s.pod_target_xcconfig = { 'ENABLE_USER_SCRIPT_SANDBOXING' => 'NO' }
+  s.user_target_xcconfig = { 'ENABLE_USER_SCRIPT_SANDBOXING' => 'NO' }
+end

--- a/Specs/SendbirdUIMessageTemplate/3.35.0/SendbirdUIMessageTemplate.podspec
+++ b/Specs/SendbirdUIMessageTemplate/3.35.0/SendbirdUIMessageTemplate.podspec
@@ -1,0 +1,30 @@
+Pod::Spec.new do |s|
+  s.name = 'SendbirdUIMessageTemplate'
+  s.version = '3.35.0'
+  s.summary = 'Sendbird UIMessageTemplate iOS Framework'
+  s.description = 'Message template UI module for Sendbird iOS SDK'
+  s.homepage = 'https://sendbird.com'
+  s.license = { :type => 'Commercial', :file => 'SendbirdUIMessageTemplate/LICENSE.md' }
+  s.authors = {
+    'Sendbird' => 'sha.sdk_deployment@sendbird.com',
+    'Jed Gyeong' => 'jed.gyeong@sendbird.com',
+    'Celine Moon' => 'celine.moon@sendbird.com',
+    'Tez Park' => 'tez.park@sendbird.com',
+    'Damon Park' => 'damon.park@sendbird.com',
+    'Young Hwang' => 'young.hwang@sendbird.com',
+    'Kai Lee' => 'kai.lee@sendbird.com'
+  }
+  s.source = {
+    :http => 'https://github.com/sendbird/sendbird-uikit-ios/releases/download/3.35.0/SendbirdUIMessageTemplate.zip',
+    :sha1 => '81d7809e66c66ca12b5693d496ab2a8935371b2e'
+  }
+  s.requires_arc = true
+  s.platform = :ios, '13.0'
+  s.documentation_url = 'https://sendbird.com/docs/uikit'
+  s.ios.vendored_frameworks = 'SendbirdUIMessageTemplate/SendbirdUIMessageTemplate.xcframework'
+  s.dependency 'SendbirdChatSDK', '>= 4.39.0'
+  s.ios.frameworks = ['UIKit', 'Foundation', 'CoreData', 'SendbirdChatSDK']
+  s.ios.library = 'icucore'
+  s.pod_target_xcconfig = { 'ENABLE_USER_SCRIPT_SANDBOXING' => 'NO' }
+  s.user_target_xcconfig = { 'ENABLE_USER_SCRIPT_SANDBOXING' => 'NO' }
+end

--- a/Specs/SendbirdUIMessageTemplate/3.35.1/SendbirdUIMessageTemplate.podspec
+++ b/Specs/SendbirdUIMessageTemplate/3.35.1/SendbirdUIMessageTemplate.podspec
@@ -1,0 +1,30 @@
+Pod::Spec.new do |s|
+  s.name = 'SendbirdUIMessageTemplate'
+  s.version = '3.35.1'
+  s.summary = 'Sendbird UIMessageTemplate iOS Framework'
+  s.description = 'Message template UI module for Sendbird iOS SDK'
+  s.homepage = 'https://sendbird.com'
+  s.license = { :type => 'Commercial', :file => 'SendbirdUIMessageTemplate/LICENSE.md' }
+  s.authors = {
+    'Sendbird' => 'sha.sdk_deployment@sendbird.com',
+    'Jed Gyeong' => 'jed.gyeong@sendbird.com',
+    'Celine Moon' => 'celine.moon@sendbird.com',
+    'Tez Park' => 'tez.park@sendbird.com',
+    'Damon Park' => 'damon.park@sendbird.com',
+    'Young Hwang' => 'young.hwang@sendbird.com',
+    'Kai Lee' => 'kai.lee@sendbird.com'
+  }
+  s.source = {
+    :http => 'https://github.com/sendbird/sendbird-uikit-ios/releases/download/3.35.1/SendbirdUIMessageTemplate.zip',
+    :sha1 => '57b174c55f024839058ecce5b9d8338266fed795'
+  }
+  s.requires_arc = true
+  s.platform = :ios, '13.0'
+  s.documentation_url = 'https://sendbird.com/docs/uikit'
+  s.ios.vendored_frameworks = 'SendbirdUIMessageTemplate/SendbirdUIMessageTemplate.xcframework'
+  s.dependency 'SendbirdChatSDK', '>= 4.39.2'
+  s.ios.frameworks = ['UIKit', 'Foundation', 'CoreData', 'SendbirdChatSDK']
+  s.ios.library = 'icucore'
+  s.pod_target_xcconfig = { 'ENABLE_USER_SCRIPT_SANDBOXING' => 'NO' }
+  s.user_target_xcconfig = { 'ENABLE_USER_SCRIPT_SANDBOXING' => 'NO' }
+end

--- a/Specs/SendbirdUIMessageTemplate/3.35.2/SendbirdUIMessageTemplate.podspec
+++ b/Specs/SendbirdUIMessageTemplate/3.35.2/SendbirdUIMessageTemplate.podspec
@@ -1,0 +1,30 @@
+Pod::Spec.new do |s|
+  s.name = 'SendbirdUIMessageTemplate'
+  s.version = '3.35.2'
+  s.summary = 'Sendbird UIMessageTemplate iOS Framework'
+  s.description = 'Message template UI module for Sendbird iOS SDK'
+  s.homepage = 'https://sendbird.com'
+  s.license = { :type => 'Commercial', :file => 'SendbirdUIMessageTemplate/LICENSE.md' }
+  s.authors = {
+    'Sendbird' => 'sha.sdk_deployment@sendbird.com',
+    'Jed Gyeong' => 'jed.gyeong@sendbird.com',
+    'Celine Moon' => 'celine.moon@sendbird.com',
+    'Tez Park' => 'tez.park@sendbird.com',
+    'Damon Park' => 'damon.park@sendbird.com',
+    'Young Hwang' => 'young.hwang@sendbird.com',
+    'Kai Lee' => 'kai.lee@sendbird.com'
+  }
+  s.source = {
+    :http => 'https://github.com/sendbird/sendbird-uikit-ios/releases/download/3.35.2/SendbirdUIMessageTemplate.zip',
+    :sha1 => 'a12a57d8858d674ff1618c77dbfe00447daf83a6'
+  }
+  s.requires_arc = true
+  s.platform = :ios, '13.0'
+  s.documentation_url = 'https://sendbird.com/docs/uikit'
+  s.ios.vendored_frameworks = 'SendbirdUIMessageTemplate/SendbirdUIMessageTemplate.xcframework'
+  s.dependency 'SendbirdChatSDK', '>= 4.39.4'
+  s.ios.frameworks = ['UIKit', 'Foundation', 'CoreData', 'SendbirdChatSDK']
+  s.ios.library = 'icucore'
+  s.pod_target_xcconfig = { 'ENABLE_USER_SCRIPT_SANDBOXING' => 'NO' }
+  s.user_target_xcconfig = { 'ENABLE_USER_SCRIPT_SANDBOXING' => 'NO' }
+end

--- a/Specs/SendbirdUIMessageTemplate/3.35.3/SendbirdUIMessageTemplate.podspec
+++ b/Specs/SendbirdUIMessageTemplate/3.35.3/SendbirdUIMessageTemplate.podspec
@@ -1,0 +1,30 @@
+Pod::Spec.new do |s|
+  s.name = 'SendbirdUIMessageTemplate'
+  s.version = '3.35.3'
+  s.summary = 'Sendbird UIMessageTemplate iOS Framework'
+  s.description = 'Message template UI module for Sendbird iOS SDK'
+  s.homepage = 'https://sendbird.com'
+  s.license = { :type => 'Commercial', :file => 'SendbirdUIMessageTemplate/LICENSE.md' }
+  s.authors = {
+    'Sendbird' => 'sha.sdk_deployment@sendbird.com',
+    'Jed Gyeong' => 'jed.gyeong@sendbird.com',
+    'Celine Moon' => 'celine.moon@sendbird.com',
+    'Tez Park' => 'tez.park@sendbird.com',
+    'Damon Park' => 'damon.park@sendbird.com',
+    'Young Hwang' => 'young.hwang@sendbird.com',
+    'Kai Lee' => 'kai.lee@sendbird.com'
+  }
+  s.source = {
+    :http => 'https://github.com/sendbird/sendbird-uikit-ios/releases/download/3.35.3/SendbirdUIMessageTemplate.zip',
+    :sha1 => '73d6518f0c1a8bc0d8818e3745f108b4eefccbf6'
+  }
+  s.requires_arc = true
+  s.platform = :ios, '13.0'
+  s.documentation_url = 'https://sendbird.com/docs/uikit'
+  s.ios.vendored_frameworks = 'SendbirdUIMessageTemplate/SendbirdUIMessageTemplate.xcframework'
+  s.dependency 'SendbirdChatSDK', '>= 4.39.4'
+  s.ios.frameworks = ['UIKit', 'Foundation', 'CoreData', 'SendbirdChatSDK']
+  s.ios.library = 'icucore'
+  s.pod_target_xcconfig = { 'ENABLE_USER_SCRIPT_SANDBOXING' => 'NO' }
+  s.user_target_xcconfig = { 'ENABLE_USER_SCRIPT_SANDBOXING' => 'NO' }
+end


### PR DESCRIPTION
## Summary

Backfill the private CocoaPods spec source with recent published versions of the four binary-xcframework SDKs, so consumers can resolve the full `auth → chat → (uikit, message-template)` chain entirely from this private source instead of falling back to the public trunk.

**36 new podspecs** (existing `SendbirdAuthSDK 1.1.2` and `SendbirdChatSDK 4.39.5` left untouched):

| Pod | Versions added | Count |
|---|---|---|
| SendbirdAuthSDK | 0.0.10–1.1.3 | 8 |
| SendbirdChatSDK | 4.37.2–4.39.4 | 8 |
| SendBirdUIKit | 3.32.1–3.35.3 | 10 |
| SendbirdUIMessageTemplate | 3.32.3–3.35.3 | 10 |

All version / source URL / sha1 / dependency values mirror the authoritative CocoaPods trunk podspecs. Per-version `s.dependency` pins (chat→auth exact-pin; uikit/message-template→chat `>=`) are preserved exactly.

## Omitted on purpose

`SendbirdAuthSDK 1.0.2` and `SendbirdChatSDK 4.38.2` are **not** included — their GitHub release assets were yanked (download URLs 404), so their trunk podspecs point at dead links. No retained version depends on either.

## Validation (no push required, run locally)

- `pod ipc spec` parses all 36 specs; folder path ↔ `s.name`/`s.version` match.
- sha1 + dependency values cross-checked against trunk.
- `pod spec lint` (real zip download + sha1 verify + framework build + dependency resolution) passed for the latest of each pod: AuthSDK 1.1.3, ChatSDK 4.39.4, UIMessageTemplate 3.35.3, SendBirdUIKit 3.35.3.
- **All 38 release-zip URLs return 200/206.**

## Notes

- `SendBirdUIKit` keeps the upstream irregular casing (capital **B** in the pod name; framework inside is `SendbirdUIKit.xcframework`).
- These pods reference external release zips via `:http`, so they do **not** depend on this repo's `<Pod>-v<version>` git tags — `pod install` works without tags.