### PR TITLE
[AA-15755] 미지원 문법 추가, 차단 및 줄바꿈 처리 개선

### DIFF
--- a/Sources/MarkdownUI/Sources/MarkdownUI/DSL/Inlines/SoftBreak.swift
+++ b/Sources/MarkdownUI/Sources/MarkdownUI/DSL/Inlines/SoftBreak.swift
@@ -2,7 +2,8 @@ import Foundation
 
 /// A soft break in a Markdown content block.
 ///
-/// A ``Markdown`` view will display a soft break as a space.
+/// A ``Markdown`` view displays a soft break according to its configured ``Mode``.
+/// The default mode displays soft breaks as line breaks.
 public struct SoftBreak: InlineContentProtocol {
   /// Creates a soft break inline element.
   public init() {}

--- a/Sources/MarkdownUI/Sources/MarkdownUI/Parser/MarkdownParser.swift
+++ b/Sources/MarkdownUI/Sources/MarkdownUI/Parser/MarkdownParser.swift
@@ -250,14 +250,14 @@ extension UnsafeNode {
   ) rethrows -> ResultType? {
     cmark_gfm_core_extensions_ensure_registered()
 
+    let markdown = MarkdownSyntaxBlocklist.process(markdown)
+
     // Create a Markdown parser and attach the GitHub syntax extensions
 
     let parser = cmark_parser_new(CMARK_OPT_DEFAULT)
     defer { cmark_parser_free(parser) }
 
-    let extensionNames: Set<String>
-
-    extensionNames = ["autolink", "strikethrough", "tagfilter", "tasklist", "table"]
+    let extensionNames: Set<String> = ["autolink", "tagfilter", "tasklist", "table"]
 
     for extensionName in extensionNames {
       guard let syntaxExtension = cmark_find_syntax_extension(extensionName) else {

--- a/Sources/MarkdownUI/Sources/MarkdownUI/Parser/MarkdownParser.swift
+++ b/Sources/MarkdownUI/Sources/MarkdownUI/Parser/MarkdownParser.swift
@@ -150,7 +150,7 @@ extension InlineNode {
     case .code:
       self = .code(unsafeNode.literal ?? "")
     case .html:
-      self = .html(unsafeNode.literal ?? "")
+      self = .text(unsafeNode.literal ?? "")
     case .emphasis:
       self = .emphasis(children: unsafeNode.children.compactMap(InlineNode.init(unsafeNode:)))
     case .strong:
@@ -257,7 +257,7 @@ extension UnsafeNode {
     let parser = cmark_parser_new(CMARK_OPT_DEFAULT)
     defer { cmark_parser_free(parser) }
 
-    let extensionNames: Set<String> = ["autolink", "tagfilter", "tasklist", "table"]
+    let extensionNames: Set<String> = ["tagfilter", "table"]
 
     for extensionName in extensionNames {
       guard let syntaxExtension = cmark_find_syntax_extension(extensionName) else {

--- a/Sources/MarkdownUI/Sources/MarkdownUI/Parser/MarkdownSyntaxBlocklist.swift
+++ b/Sources/MarkdownUI/Sources/MarkdownUI/Parser/MarkdownSyntaxBlocklist.swift
@@ -1,0 +1,142 @@
+import Foundation
+
+enum MarkdownSyntaxBlocklist {
+  static func process(_ markdown: String) -> String {
+    guard !markdown.isEmpty else { return markdown }
+
+    var result = ""
+    result.reserveCapacity(markdown.utf8.count)
+    var activeFence: Fence?
+
+    markdown.enumerateSubstrings(
+      in: markdown.startIndex..<markdown.endIndex,
+      options: [.byLines, .substringNotRequired]
+    ) { _, lineRange, enclosingRange, _ in
+      let line = markdown[lineRange]
+
+      if let fence = activeFence {
+        result.append(contentsOf: line)
+        if isClosingFence(line, for: fence) {
+          activeFence = nil
+        }
+      } else if let fence = openingFence(in: line) {
+        activeFence = fence
+        result.append(contentsOf: line)
+      } else {
+        result.append(contentsOf: neutralizingReferenceDefinition(in: line))
+      }
+
+      result.append(contentsOf: markdown[lineRange.upperBound..<enclosingRange.upperBound])
+    }
+
+    return result
+  }
+}
+
+private extension MarkdownSyntaxBlocklist {
+  struct Fence {
+    let marker: Character
+    let length: Int
+  }
+
+  struct FenceRun {
+    let marker: Character
+    let length: Int
+    let remainder: Substring
+  }
+
+  static func openingFence(in line: Substring) -> Fence? {
+    guard let run = fenceRun(in: line) else { return nil }
+    if run.marker == "`", run.remainder.contains("`") {
+      return nil
+    }
+    return Fence(marker: run.marker, length: run.length)
+  }
+
+  static func isClosingFence(_ line: Substring, for fence: Fence) -> Bool {
+    guard let run = fenceRun(in: line),
+          run.marker == fence.marker,
+          run.length >= fence.length else {
+      return false
+    }
+    return run.remainder.allSatisfy { $0 == " " || $0 == "\t" }
+  }
+
+  static func fenceRun(in line: Substring) -> FenceRun? {
+    guard let contentStart = contentStart(in: line) else { return nil }
+    let marker = line[contentStart]
+    guard marker == "`" || marker == "~" else { return nil }
+
+    var markerEnd = contentStart
+    var length = 0
+    while markerEnd < line.endIndex, line[markerEnd] == marker {
+      length += 1
+      markerEnd = line.index(after: markerEnd)
+    }
+    guard length >= 3 else { return nil }
+
+    return FenceRun(marker: marker, length: length, remainder: line[markerEnd...])
+  }
+
+  static func neutralizingReferenceDefinition(in line: Substring) -> String {
+    guard let opener = referenceDefinitionOpener(in: line) else {
+      return String(line)
+    }
+
+    var result = String(line[..<opener])
+    result.append("\\")
+    result.append(contentsOf: line[opener...])
+    return result
+  }
+
+  static func referenceDefinitionOpener(in line: Substring) -> Substring.Index? {
+    guard let opener = contentStart(in: line), line[opener] == "[" else {
+      return nil
+    }
+
+    var index = line.index(after: opener)
+    guard index < line.endIndex else { return nil }
+
+    var labelLength = 0
+    var isEscaped = false
+    while index < line.endIndex {
+      let character = line[index]
+
+      if isEscaped {
+        isEscaped = false
+        labelLength += 1
+      } else if character == "\\" {
+        isEscaped = true
+        labelLength += 1
+      } else if character == "[" {
+        return nil
+      } else if character == "]" {
+        let colon = line.index(after: index)
+        guard labelLength > 0,
+              labelLength <= 999,
+              colon < line.endIndex,
+              line[colon] == ":" else {
+          return nil
+        }
+        return opener
+      } else {
+        labelLength += 1
+      }
+
+      index = line.index(after: index)
+    }
+
+    return nil
+  }
+
+  static func contentStart(in line: Substring) -> Substring.Index? {
+    var index = line.startIndex
+    var indentation = 0
+    while index < line.endIndex, line[index] == " " {
+      indentation += 1
+      guard indentation <= 3 else { return nil }
+      index = line.index(after: index)
+    }
+    return index < line.endIndex ? index : nil
+  }
+}

--- a/Sources/MarkdownUI/Sources/MarkdownUI/Views/Environment/Environment+SoftBreakMode.swift
+++ b/Sources/MarkdownUI/Sources/MarkdownUI/Views/Environment/Environment+SoftBreakMode.swift
@@ -19,5 +19,5 @@ extension EnvironmentValues {
 }
 
 private struct SoftBreakModeKey: EnvironmentKey {
-  static let defaultValue: SoftBreak.Mode = .space
+  static let defaultValue: SoftBreak.Mode = .lineBreak
 }


### PR DESCRIPTION
## 관련 티켓

- [AA-15755](https://sendbird.atlassian.net/browse/AA-15755)

## 변경 사항

Confluence의 기본 Markdown 문법 지원 Goal에 맞게 iOS Markdown 파서의 지원 범위를 조정했습니다.

| 문법 | 변경 후 동작 |
| --- | --- |
| Strikethrough (`~text~`, `~~text~~`) | 미지원 — 원문 그대로 표시 |
| Reference link / definition | 미지원 — 원문 그대로 표시 |
| Soft line break (`\n`) | 지원 — 줄 끝 공백 없이 실제 줄바꿈 |
| Task list (`- [ ]`, `- [x]`) | 미지원 — 체크박스 없이 일반 bullet과 `[ ]`, `[x]` 표시 |
| Inline HTML (`<b>`, `<br>`) | 미지원 — HTML로 렌더링하지 않고 태그 문자열 표시 |
| Bare URL (`https://www.sendbird.com`) | 미지원 — 일반 텍스트로 표시 |
| Autolink (`<https://www.sendbird.com>`) | 지원 — 링크로 표시 |
| Markdown link (`[텍스트](https://www.sendbird.com)`) | 지원 — 링크로 표시 |

추가로 코드 블록 내부의 reference definition은 blocklist 전처리 대상에서 제외하고, 필요한 경우 `.markdownSoftBreakMode(.space)`로 기존 soft break 동작을 선택할 수 있도록 유지했습니다.

## 변경 배경

AI Agent 응답의 상품명이나 숫자 범위에는 `~` 문자가 포함될 수 있습니다. 기존 cmark 설정은 이를 취소선 구분자로 해석해 의도하지 않은 취소선이 표시되었습니다.

Reference link 문법도 의도하지 않게 처리되어 참조 라벨이 링크로 변환되고 definition이 화면에서 사라질 수 있었습니다. Markdown 문법 지원 Goal과 플랫폼 간 동작을 맞추기 위해 blocklist 전처리와 cmark extension 구성을 조정했습니다.

## 주요 구현

- cmark 파싱 전에 reference link definition을 무력화하는 blocklist 전처리를 적용했습니다.
- `strikethrough`, `autolink`, `tasklist` GFM extension을 파서에서 제외했습니다.
- inline HTML 노드를 HTML이 아닌 일반 텍스트 노드로 변환했습니다.
- soft break 기본 모드를 `.space`에서 `.lineBreak`로 변경했습니다.

## 검증

- `swift build --scratch-path /private/tmp/sendbird-ios-distribution-goal-build` 성공
- 실제 배포 패키지를 의존하는 Goal 회귀 probe 8개 통과
  - bare URL 미링크
  - `<url>` autolink 및 Markdown link 지원
  - task list 일반 bullet 처리
  - inline HTML literal 처리
  - 단일 개행 유지
  - 취소선 및 reference link 미지원
- 통합 테스트 프로젝트의 Markdown 파서 회귀 테스트 10개 통과
- iPhone 17 Pro / iOS 26.5 시뮬레이터 테스트 성공


[AA-15755]: https://sendbird.atlassian.net/browse/AA-15755?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ