### PR TITLE
feat(MarkdownUI): markdownImageTapHandler for standalone image taps

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -43,6 +43,13 @@ let package = Package(
             exclude: [
                 "Documentation.docc"
             ]
+        ),
+
+        // MarkdownUI Tests (SwiftPM-only; not part of any published product)
+        .testTarget(
+            name: "SendbirdMarkdownUITests",
+            dependencies: ["SendbirdMarkdownUI"],
+            path: "Sources/MarkdownUI/Tests/MarkdownUITests"
         )
     ]
 )

--- a/Sources/MarkdownUI/Sources/MarkdownUI/Extensibility/MarkdownImageInfo.swift
+++ b/Sources/MarkdownUI/Sources/MarkdownUI/Extensibility/MarkdownImageInfo.swift
@@ -1,0 +1,53 @@
+import Foundation
+
+/// A clickable markdown image, as rendered by the ``Markdown`` view.
+public struct MarkdownImageInfo: Hashable, Sendable {
+  /// The resolved image URL.
+  public let url: URL
+
+  /// The rendered plain text of the image's alt content. Empty when the markdown has no alt text.
+  public let alt: String
+
+  public init(url: URL, alt: String) {
+    self.url = url
+    self.alt = alt
+  }
+}
+
+extension MarkdownContent {
+  /// The images that the ``Markdown`` view renders as tappable, in document order.
+  ///
+  /// Matches the view's render paths exactly: top-level images of paragraph blocks
+  /// (single-image paragraphs, image-only flows, and paragraphs mixing text and images),
+  /// including paragraphs nested in blockquotes and lists. Images wrapped in a markdown
+  /// link keep their link behavior and are excluded, as are images whose URL cannot be
+  /// resolved. Images in headings, tables, and inline containers (emphasis, links) render
+  /// as inline text attachments and are not tappable, so they are not collected.
+  ///
+  /// - Parameter imageBaseURL: The base URL for resolving relative image URLs. Pass the
+  ///   same value used for the ``Markdown`` view's `imageBaseURL`. The default is `nil`.
+  public func clickableImages(relativeTo imageBaseURL: URL? = nil) -> [MarkdownImageInfo] {
+    Self.clickableImages(in: self.blocks, imageBaseURL: imageBaseURL)
+  }
+
+  private static func clickableImages(
+    in blocks: [BlockNode],
+    imageBaseURL: URL?
+  ) -> [MarkdownImageInfo] {
+    blocks.flatMap { block -> [MarkdownImageInfo] in
+      switch block {
+      case .paragraph(let content):
+        return content.compactMap { inline in
+          guard case .image(let source, let children) = inline,
+            let url = URL(string: source, relativeTo: imageBaseURL)
+          else {
+            return nil
+          }
+          return MarkdownImageInfo(url: url, alt: children.renderPlainText())
+        }
+      default:
+        return self.clickableImages(in: block.children, imageBaseURL: imageBaseURL)
+      }
+    }
+  }
+}

--- a/Sources/MarkdownUI/Sources/MarkdownUI/Extensibility/MarkdownImageTapHandler.swift
+++ b/Sources/MarkdownUI/Sources/MarkdownUI/Extensibility/MarkdownImageTapHandler.swift
@@ -1,7 +1,7 @@
 import SwiftUI
 
 /// Information about a tapped standalone markdown image (`![alt](url)`).
-public struct MarkdownImageTapInfo: Equatable {
+public struct MarkdownImageTapInfo: Hashable, Sendable {
   /// The resolved image URL.
   public let url: URL
 
@@ -17,8 +17,10 @@ public struct MarkdownImageTapInfo: Equatable {
 extension View {
   /// Sets a handler invoked when a standalone (non link-wrapped) markdown image is tapped.
   ///
-  /// Images wrapped in a markdown link (`[![alt](img)](link)`) keep their link
-  /// behavior and never trigger this handler.
+  /// The handler applies to standalone image paragraphs, image-only paragraphs
+  /// rendered as an image flow, and images inside paragraphs that mix text and
+  /// images. Images wrapped in a markdown link (`[![alt](img)](link)`) keep
+  /// their link behavior and never trigger this handler.
   public func markdownImageTapHandler(
     _ handler: ((MarkdownImageTapInfo) -> Void)?
   ) -> some View {
@@ -35,4 +37,31 @@ extension EnvironmentValues {
 
 private struct ImageTapHandlerKey: EnvironmentKey {
   static let defaultValue: ((MarkdownImageTapInfo) -> Void)? = nil
+}
+
+extension View {
+  func imageTap(url: URL?, alt: String, enabled: Bool) -> some View {
+    self.modifier(ImageTapModifier(url: url, alt: alt, enabled: enabled))
+  }
+}
+
+struct ImageTapModifier: ViewModifier {
+  @Environment(\.imageTapHandler) private var imageTapHandler
+
+  let url: URL?
+  let alt: String
+  let enabled: Bool
+
+  func body(content: Content) -> some View {
+    if self.enabled, let url = self.url, let handler = self.imageTapHandler {
+      Button {
+        handler(.init(url: url, alt: self.alt))
+      } label: {
+        content
+      }
+      .buttonStyle(.plain)
+    } else {
+      content
+    }
+  }
 }

--- a/Sources/MarkdownUI/Sources/MarkdownUI/Extensibility/MarkdownImageTapHandler.swift
+++ b/Sources/MarkdownUI/Sources/MarkdownUI/Extensibility/MarkdownImageTapHandler.swift
@@ -2,15 +2,40 @@ import SwiftUI
 
 /// Information about a tapped standalone markdown image (`![alt](url)`).
 public struct MarkdownImageTapInfo: Hashable, Sendable {
-  /// The resolved image URL.
+  /// The resolved URL of the tapped image.
   public let url: URL
 
-  /// The alt text of the image. Empty when the markdown has no alt text.
+  /// The alt text of the tapped image. Empty when the markdown has no alt text.
   public let alt: String
 
-  public init(url: URL, alt: String) {
+  /// All clickable images of the rendered document, in document order
+  /// (see ``MarkdownContent/clickableImages(relativeTo:)``).
+  /// Always contains the tapped image.
+  public let images: [MarkdownImageInfo]
+
+  /// The index of the tapped image within ``images``. When a fully identical
+  /// url+alt image occurs multiple times in one document, the occurrences cannot
+  /// be distinguished and the first one wins; the list itself stays complete.
+  public let currentIndex: Int
+
+  public init(url: URL, alt: String, images: [MarkdownImageInfo], currentIndex: Int) {
     self.url = url
     self.alt = alt
+    self.images = images
+    self.currentIndex = currentIndex
+  }
+
+  /// Builds the tap payload for a tapped image against the rendered document's
+  /// clickable images. A tapped image is always present in the rendered list;
+  /// should they ever diverge, the payload degrades to a single-item list so the
+  /// caller can still open the tapped image.
+  static func resolving(url: URL, alt: String, in images: [MarkdownImageInfo]) -> MarkdownImageTapInfo {
+    if let index = images.firstIndex(where: { $0.url == url && $0.alt == alt })
+      ?? images.firstIndex(where: { $0.url == url })
+    {
+      return .init(url: url, alt: alt, images: images, currentIndex: index)
+    }
+    return .init(url: url, alt: alt, images: [.init(url: url, alt: alt)], currentIndex: 0)
   }
 }
 
@@ -21,6 +46,9 @@ extension View {
   /// rendered as an image flow, and images inside paragraphs that mix text and
   /// images. Images wrapped in a markdown link (`[![alt](img)](link)`) keep
   /// their link behavior and never trigger this handler.
+  ///
+  /// The payload carries the tapped image plus the document's full clickable image
+  /// list and the tapped index, resolved from the same cmark AST that rendered the view.
   public func markdownImageTapHandler(
     _ handler: ((MarkdownImageTapInfo) -> Void)?
   ) -> some View {
@@ -33,10 +61,21 @@ extension EnvironmentValues {
     get { self[ImageTapHandlerKey.self] }
     set { self[ImageTapHandlerKey.self] = newValue }
   }
+
+  /// Set by the root ``Markdown`` view: the user handler wrapped with the rendered
+  /// document's clickable images, so tap sites only need to report (url, alt).
+  var resolvedImageTapHandler: ((URL, String) -> Void)? {
+    get { self[ResolvedImageTapHandlerKey.self] }
+    set { self[ResolvedImageTapHandlerKey.self] = newValue }
+  }
 }
 
 private struct ImageTapHandlerKey: EnvironmentKey {
   static let defaultValue: ((MarkdownImageTapInfo) -> Void)? = nil
+}
+
+private struct ResolvedImageTapHandlerKey: EnvironmentKey {
+  static let defaultValue: ((URL, String) -> Void)? = nil
 }
 
 extension View {
@@ -46,16 +85,16 @@ extension View {
 }
 
 struct ImageTapModifier: ViewModifier {
-  @Environment(\.imageTapHandler) private var imageTapHandler
+  @Environment(\.resolvedImageTapHandler) private var resolvedImageTapHandler
 
   let url: URL?
   let alt: String
   let enabled: Bool
 
   func body(content: Content) -> some View {
-    if self.enabled, let url = self.url, let handler = self.imageTapHandler {
+    if self.enabled, let url = self.url, let handler = self.resolvedImageTapHandler {
       Button {
-        handler(.init(url: url, alt: self.alt))
+        handler(url, self.alt)
       } label: {
         content
       }

--- a/Sources/MarkdownUI/Sources/MarkdownUI/Extensibility/MarkdownImageTapHandler.swift
+++ b/Sources/MarkdownUI/Sources/MarkdownUI/Extensibility/MarkdownImageTapHandler.swift
@@ -1,0 +1,38 @@
+import SwiftUI
+
+/// Information about a tapped standalone markdown image (`![alt](url)`).
+public struct MarkdownImageTapInfo: Equatable {
+  /// The resolved image URL.
+  public let url: URL
+
+  /// The alt text of the image. Empty when the markdown has no alt text.
+  public let alt: String
+
+  public init(url: URL, alt: String) {
+    self.url = url
+    self.alt = alt
+  }
+}
+
+extension View {
+  /// Sets a handler invoked when a standalone (non link-wrapped) markdown image is tapped.
+  ///
+  /// Images wrapped in a markdown link (`[![alt](img)](link)`) keep their link
+  /// behavior and never trigger this handler.
+  public func markdownImageTapHandler(
+    _ handler: ((MarkdownImageTapInfo) -> Void)?
+  ) -> some View {
+    self.environment(\.imageTapHandler, handler)
+  }
+}
+
+extension EnvironmentValues {
+  var imageTapHandler: ((MarkdownImageTapInfo) -> Void)? {
+    get { self[ImageTapHandlerKey.self] }
+    set { self[ImageTapHandlerKey.self] = newValue }
+  }
+}
+
+private struct ImageTapHandlerKey: EnvironmentKey {
+  static let defaultValue: ((MarkdownImageTapInfo) -> Void)? = nil
+}

--- a/Sources/MarkdownUI/Sources/MarkdownUI/Extensibility/MarkdownLinkInfo.swift
+++ b/Sources/MarkdownUI/Sources/MarkdownUI/Extensibility/MarkdownLinkInfo.swift
@@ -1,0 +1,62 @@
+import Foundation
+
+/// A clickable link rendered by the ``Markdown`` view.
+public struct MarkdownLinkInfo: Hashable, Sendable {
+  /// The resolved link destination.
+  public let url: URL
+
+  /// The rendered plain text of the link's label. For a link-wrapped image this is
+  /// the image's alt text. For an autolinked bare URL this is the URL string itself.
+  public let text: String
+
+  public init(url: URL, text: String) {
+    self.url = url
+    self.text = text
+  }
+}
+
+extension MarkdownContent {
+  /// The links that the ``Markdown`` view renders as clickable, in document order.
+  ///
+  /// Collected from the same cmark AST used for rendering: markdown links, GFM
+  /// autolinked bare URLs, and link-wrapped images (outer destination) — wherever
+  /// they render (paragraphs, headings, blockquotes, lists, tables). Standalone
+  /// images are not links, code spans/blocks never produce links, and links whose
+  /// destination cannot be resolved are excluded.
+  ///
+  /// - Parameter baseURL: The base URL for resolving relative destinations. Pass the
+  ///   same value used for the ``Markdown`` view's `baseURL`. The default is `nil`.
+  public func clickableLinks(relativeTo baseURL: URL? = nil) -> [MarkdownLinkInfo] {
+    Self.clickableLinks(in: self.blocks, baseURL: baseURL)
+  }
+
+  private static func clickableLinks(in blocks: [BlockNode], baseURL: URL?) -> [MarkdownLinkInfo] {
+    blocks.flatMap { block -> [MarkdownLinkInfo] in
+      switch block {
+      case .paragraph(let content), .heading(_, let content):
+        return self.links(in: content, baseURL: baseURL)
+      case .table(_, let rows):
+        return rows.flatMap { row in
+          row.cells.flatMap { self.links(in: $0.content, baseURL: baseURL) }
+        }
+      default:
+        return self.clickableLinks(in: block.children, baseURL: baseURL)
+      }
+    }
+  }
+
+  private static func links(in inlines: [InlineNode], baseURL: URL?) -> [MarkdownLinkInfo] {
+    inlines.flatMap { inline -> [MarkdownLinkInfo] in
+      switch inline {
+      case .link(let destination, let children):
+        guard let url = URL(string: destination, relativeTo: baseURL) else { return [] }
+        return [MarkdownLinkInfo(url: url, text: children.renderPlainText())]
+      case .image:
+        // Links inside an image's alt render as plain text, never as tappable links.
+        return []
+      default:
+        return self.links(in: inline.children, baseURL: baseURL)
+      }
+    }
+  }
+}

--- a/Sources/MarkdownUI/Sources/MarkdownUI/Views/Blocks/ParagraphView.swift
+++ b/Sources/MarkdownUI/Sources/MarkdownUI/Views/Blocks/ParagraphView.swift
@@ -119,6 +119,7 @@ private struct CompactImageView: View {
     @ViewBuilder private var label: some View {
         if let url = URL(string: source, relativeTo: baseURL) {
             imageProvider.makeImage(url: url)
+                .imageTap(url: url, alt: alt, enabled: true)
                 .accessibilityLabel(alt)
         }
     }

--- a/Sources/MarkdownUI/Sources/MarkdownUI/Views/Inlines/ImageView.swift
+++ b/Sources/MarkdownUI/Sources/MarkdownUI/Views/Inlines/ImageView.swift
@@ -23,6 +23,7 @@ struct ImageView: View {
   private var label: some View {
     self.imageProvider.makeImage(url: self.url)
       .link(destination: self.data.destination)
+      .imageTap(url: self.url, alt: self.data.alt, enabled: self.data.destination == nil)
       .accessibilityLabel(self.data.alt)
   }
 
@@ -79,6 +80,33 @@ private struct LinkModifier: ViewModifier {
     if let url {
       Button {
         self.openURL(url)
+      } label: {
+        content
+      }
+      .buttonStyle(.plain)
+    } else {
+      content
+    }
+  }
+}
+
+extension View {
+  fileprivate func imageTap(url: URL?, alt: String, enabled: Bool) -> some View {
+    self.modifier(ImageTapModifier(url: url, alt: alt, enabled: enabled))
+  }
+}
+
+private struct ImageTapModifier: ViewModifier {
+  @Environment(\.imageTapHandler) private var imageTapHandler
+
+  let url: URL?
+  let alt: String
+  let enabled: Bool
+
+  func body(content: Content) -> some View {
+    if self.enabled, let url = self.url, let handler = self.imageTapHandler {
+      Button {
+        handler(.init(url: url, alt: self.alt))
       } label: {
         content
       }

--- a/Sources/MarkdownUI/Sources/MarkdownUI/Views/Inlines/ImageView.swift
+++ b/Sources/MarkdownUI/Sources/MarkdownUI/Views/Inlines/ImageView.swift
@@ -89,30 +89,3 @@ private struct LinkModifier: ViewModifier {
     }
   }
 }
-
-extension View {
-  fileprivate func imageTap(url: URL?, alt: String, enabled: Bool) -> some View {
-    self.modifier(ImageTapModifier(url: url, alt: alt, enabled: enabled))
-  }
-}
-
-private struct ImageTapModifier: ViewModifier {
-  @Environment(\.imageTapHandler) private var imageTapHandler
-
-  let url: URL?
-  let alt: String
-  let enabled: Bool
-
-  func body(content: Content) -> some View {
-    if self.enabled, let url = self.url, let handler = self.imageTapHandler {
-      Button {
-        handler(.init(url: url, alt: self.alt))
-      } label: {
-        content
-      }
-      .buttonStyle(.plain)
-    } else {
-      content
-    }
-  }
-}

--- a/Sources/MarkdownUI/Sources/MarkdownUI/Views/Markdown.swift
+++ b/Sources/MarkdownUI/Sources/MarkdownUI/Views/Markdown.swift
@@ -191,6 +191,7 @@ import SwiftUI
 public struct Markdown: View {
   @Environment(\.colorScheme) private var colorScheme
   @Environment(\.theme.text) private var text
+  @Environment(\.imageTapHandler) private var imageTapHandler
 
   private let content: MarkdownContent
   private let baseURL: URL?
@@ -219,10 +220,24 @@ public struct Markdown: View {
     .textStyle(self.text)
     .environment(\.baseURL, self.baseURL)
     .environment(\.imageBaseURL, self.imageBaseURL)
+    .environment(\.resolvedImageTapHandler, self.resolvedImageTapHandler)
   }
 
   private var blocks: [BlockNode] {
     self.content.blocks.filterImagesMatching(colorScheme: self.colorScheme)
+  }
+
+  /// Wraps the user's `markdownImageTapHandler` with the clickable image list of the
+  /// blocks this view actually renders (color-scheme filtered), so every tap site
+  /// delivers the full document context. The list is resolved lazily at tap time.
+  private var resolvedImageTapHandler: ((URL, String) -> Void)? {
+    guard let handler = self.imageTapHandler else { return nil }
+    let blocks = self.blocks
+    let imageBaseURL = self.imageBaseURL
+    return { url, alt in
+      let images = MarkdownContent(blocks: blocks).clickableImages(relativeTo: imageBaseURL)
+      handler(.resolving(url: url, alt: alt, in: images))
+    }
   }
 }
 

--- a/Sources/MarkdownUI/Tests/MarkdownUITests/ClickableImagesTests.swift
+++ b/Sources/MarkdownUI/Tests/MarkdownUITests/ClickableImagesTests.swift
@@ -1,0 +1,134 @@
+import XCTest
+
+@testable import SendbirdMarkdownUI
+
+/// `MarkdownContent.clickableImages(relativeTo:)` — the parser-backed list of images that the
+/// `Markdown` view renders as tappable. Must match the render paths exactly: top-level images
+/// of paragraph blocks (single image / image flow / mixed paragraphs), document order,
+/// link-wrapped images excluded (link priority), unresolvable URLs excluded.
+final class ClickableImagesTests: XCTestCase {
+
+  private func images(_ markdown: String) -> [(url: String, alt: String)] {
+    MarkdownContent(markdown).clickableImages().map { ($0.url.absoluteString, $0.alt) }
+  }
+
+  // MARK: - Collection
+
+  func testStandaloneImageIsClickable() {
+    let result = images("![a cat](https://example.com/cat.png)")
+    XCTAssertEqual(result.count, 1)
+    XCTAssertEqual(result[0].url, "https://example.com/cat.png")
+    XCTAssertEqual(result[0].alt, "a cat")
+  }
+
+  func testDocumentOrderAcrossParagraphsAndFlows() {
+    let markdown = """
+      ![one](https://e.com/1.png)
+
+      text before ![two](https://e.com/2.png) text after
+
+      ![three](https://e.com/3.png) ![four](https://e.com/4.png)
+      """
+    XCTAssertEqual(
+      images(markdown).map(\.url),
+      ["https://e.com/1.png", "https://e.com/2.png", "https://e.com/3.png", "https://e.com/4.png"]
+    )
+  }
+
+  func testNestedParagraphsInBlockquoteAndListAreIncluded() {
+    let markdown = """
+      > ![quoted](https://e.com/q.png)
+
+      - ![listed](https://e.com/l.png)
+      """
+    XCTAssertEqual(images(markdown).map(\.url), ["https://e.com/q.png", "https://e.com/l.png"])
+  }
+
+  func testIdenticalDuplicatesAreAllCollected() {
+    let markdown = "![a](https://e.com/i.png) and ![a](https://e.com/i.png)"
+    XCTAssertEqual(images(markdown).count, 2)
+  }
+
+  // MARK: - Exclusions (link priority, render parity)
+
+  func testLinkWrappedImageIsExcluded() {
+    let markdown = "[![badge](https://e.com/badge.png)](https://e.com/repo)"
+    XCTAssertEqual(images(markdown).count, 0)
+  }
+
+  func testLinkWrappedImageInFlowIsExcludedButSiblingsRemain() {
+    let markdown = "![a](https://e.com/a.png) [![b](https://e.com/b.png)](https://e.com/link)"
+    XCTAssertEqual(images(markdown).map(\.url), ["https://e.com/a.png"])
+  }
+
+  func testImageInsideEmphasisIsNotClickable() {
+    // Rendered through InlineText (inline image provider), not a tappable image view.
+    XCTAssertEqual(images("*![a](https://e.com/i.png)*").count, 0)
+  }
+
+  func testImageInHeadingIsNotClickable() {
+    XCTAssertEqual(images("# ![a](https://e.com/i.png)").count, 0)
+  }
+
+  func testImageInTableCellIsNotClickable() {
+    let markdown = """
+      | col |
+      | --- |
+      | ![a](https://e.com/i.png) |
+      """
+    XCTAssertEqual(images(markdown).count, 0)
+  }
+
+  func testEmptyDestinationIsExcluded() {
+    XCTAssertEqual(images("![a]()").count, 0)
+  }
+
+  // MARK: - cmark parity (scanner divergences reported in review)
+
+  func testImageInIndentedCodeBlockIsExcluded() {
+    let markdown = "    ![a](https://e.com/i.png)"
+    XCTAssertEqual(images(markdown).count, 0)
+  }
+
+  func testImageInFencedCodeBlockIsExcluded() {
+    let markdown = """
+      ```
+      ![a](https://e.com/i.png)
+      ```
+      """
+    XCTAssertEqual(images(markdown).count, 0)
+  }
+
+  func testAngleBracketDestinationIsCollected() {
+    let result = images("![a](<https://e.com/i.png>)")
+    XCTAssertEqual(result.map(\.url), ["https://e.com/i.png"])
+  }
+
+  func testUnclosedTitleIsLiteralTextNotAnImage() {
+    XCTAssertEqual(images("![a](https://e.com/i.png \"title)").count, 0)
+  }
+
+  func testQuotedTitleIsCollectedWithoutTitleInURL() {
+    let result = images("![a](https://e.com/i.png \"a title\")")
+    XCTAssertEqual(result.map(\.url), ["https://e.com/i.png"])
+  }
+
+  func testStreamingPartialTokenIsNotAnImage() {
+    XCTAssertEqual(images("look at this ![a](https://e.com/i.pn").count, 0)
+  }
+
+  // MARK: - Alt text is the rendered plain text
+
+  func testAltTextRendersInlineFormatting() {
+    let result = images("![_snake_case_ **bold** `code`](https://e.com/i.png)")
+    XCTAssertEqual(result[0].alt, "snake_case bold code")
+  }
+
+  // MARK: - Base URL resolution
+
+  func testRelativeSourceResolvesAgainstBaseURL() {
+    let content = MarkdownContent("![a](/img/cat.png)")
+    let result = content.clickableImages(relativeTo: URL(string: "https://example.com"))
+    XCTAssertEqual(result.map(\.url.absoluteString), ["https://example.com/img/cat.png"])
+  }
+}

--- a/Sources/MarkdownUI/Tests/MarkdownUITests/ClickableLinksTests.swift
+++ b/Sources/MarkdownUI/Tests/MarkdownUITests/ClickableLinksTests.swift
@@ -1,0 +1,75 @@
+import XCTest
+
+@testable import SendbirdMarkdownUI
+
+/// `MarkdownContent.clickableLinks(relativeTo:)` — the parser-backed list of links the
+/// rendered document exposes, in document order. Covers markdown links, GFM autolinked
+/// bare URLs, and link-wrapped images (outer destination). Standalone images are not
+/// links. Same cmark AST as rendering, so code spans/blocks and streaming-partial
+/// tokens never produce phantom links.
+final class ClickableLinksTests: XCTestCase {
+
+  private func links(_ markdown: String) -> [(text: String, url: String)] {
+    MarkdownContent(markdown).clickableLinks().map { ($0.text, $0.url.absoluteString) }
+  }
+
+  func testMarkdownLinkIsCollected() {
+    let result = links("[the docs](https://sendbird.com/docs)")
+    XCTAssertEqual(result.count, 1)
+    XCTAssertEqual(result[0].text, "the docs")
+    XCTAssertEqual(result[0].url, "https://sendbird.com/docs")
+  }
+
+  func testBareURLIsAutolinked() {
+    let result = links("see https://example.com/page for details")
+    XCTAssertEqual(result.map(\.url), ["https://example.com/page"])
+    XCTAssertEqual(result.map(\.text), ["https://example.com/page"])
+  }
+
+  func testLinkWrappedImageUsesOuterDestinationAndAltAsText() {
+    // Regression (PR #588 review): the VoiceOver link action must open the outer
+    // link, not the inner image URL.
+    let result = links("[![badge](https://e.com/badge.png)](https://e.com/repo)")
+    XCTAssertEqual(result.count, 1)
+    XCTAssertEqual(result[0].url, "https://e.com/repo")
+    XCTAssertEqual(result[0].text, "badge")
+  }
+
+  func testStandaloneImageIsNotALink() {
+    // Regression (PR #588 review): image syntax must not produce a link action.
+    XCTAssertEqual(links("![alt](https://e.com/i.png)").count, 0)
+  }
+
+  func testDocumentOrderAcrossBlocks() {
+    let markdown = """
+      # heading [first](https://e.com/1)
+
+      body [second](https://e.com/2) and https://e.com/3
+      """
+    XCTAssertEqual(links(markdown).map(\.url), ["https://e.com/1", "https://e.com/2", "https://e.com/3"])
+  }
+
+  func testLinkInCodeSpanIsNotCollected() {
+    XCTAssertEqual(links("`[a](https://e.com)` and https://e.com/real").map(\.url), ["https://e.com/real"])
+  }
+
+  func testDuplicateLinksAreAllCollected() {
+    let markdown = "[a](https://e.com/x) then again https://e.com/x"
+    XCTAssertEqual(links(markdown).count, 2)
+  }
+
+  func testEmptyOrInvalidDestinationIsExcluded() {
+    XCTAssertEqual(links("[text]()").count, 0)
+  }
+
+  func testRelativeDestinationResolvesAgainstBaseURL() {
+    let content = MarkdownContent("[docs](/docs)")
+    let result = content.clickableLinks(relativeTo: URL(string: "https://sendbird.com"))
+    XCTAssertEqual(result.map(\.url.absoluteString), ["https://sendbird.com/docs"])
+  }
+
+  func testNestedEmphasisTextIsRenderedPlain() {
+    let result = links("[**bold** _label_](https://e.com)")
+    XCTAssertEqual(result[0].text, "bold label")
+  }
+}

--- a/Sources/MarkdownUI/Tests/MarkdownUITests/ImageTapResolutionTests.swift
+++ b/Sources/MarkdownUI/Tests/MarkdownUITests/ImageTapResolutionTests.swift
@@ -1,0 +1,60 @@
+import XCTest
+
+@testable import SendbirdMarkdownUI
+
+/// `MarkdownImageTapInfo.resolving(url:alt:in:)` — builds the tap payload delivered to
+/// `markdownImageTapHandler` from the tapped image and the document's clickable images.
+/// Contract: `images` always contains the tapped image and `currentIndex` is always valid.
+final class ImageTapResolutionTests: XCTestCase {
+
+  private func info(_ url: String, _ alt: String) -> MarkdownImageInfo {
+    MarkdownImageInfo(url: URL(string: url)!, alt: alt)
+  }
+
+  func testMatchesTappedImageByURLAndAlt() {
+    let images = [info("https://e.com/1.png", "one"), info("https://e.com/2.png", "two")]
+    let tap = MarkdownImageTapInfo.resolving(
+      url: URL(string: "https://e.com/2.png")!, alt: "two", in: images
+    )
+    XCTAssertEqual(tap.currentIndex, 1)
+    XCTAssertEqual(tap.images, images)
+    XCTAssertEqual(tap.url.absoluteString, "https://e.com/2.png")
+    XCTAssertEqual(tap.alt, "two")
+  }
+
+  func testSameURLDifferentAltMatchesTheAltOccurrence() {
+    let images = [info("https://e.com/i.png", "first"), info("https://e.com/i.png", "second")]
+    let tap = MarkdownImageTapInfo.resolving(
+      url: URL(string: "https://e.com/i.png")!, alt: "second", in: images
+    )
+    XCTAssertEqual(tap.currentIndex, 1)
+  }
+
+  func testAltMismatchFallsBackToFirstURLMatch() {
+    let images = [info("https://e.com/1.png", "one"), info("https://e.com/2.png", "two")]
+    let tap = MarkdownImageTapInfo.resolving(
+      url: URL(string: "https://e.com/2.png")!, alt: "stale alt", in: images
+    )
+    XCTAssertEqual(tap.currentIndex, 1)
+  }
+
+  func testIdenticalDuplicatesResolveToFirstOccurrence() {
+    // Known limitation (deferred): occurrences of a fully identical url+alt image
+    // cannot be distinguished; the first one wins. The pager list stays complete.
+    let images = [info("https://e.com/i.png", "a"), info("https://e.com/i.png", "a")]
+    let tap = MarkdownImageTapInfo.resolving(
+      url: URL(string: "https://e.com/i.png")!, alt: "a", in: images
+    )
+    XCTAssertEqual(tap.currentIndex, 0)
+    XCTAssertEqual(tap.images.count, 2)
+  }
+
+  func testTappedImageMissingFromListFallsBackToSingleItemPayload() {
+    let images = [info("https://e.com/other.png", "other")]
+    let tap = MarkdownImageTapInfo.resolving(
+      url: URL(string: "https://e.com/tapped.png")!, alt: "tapped", in: images
+    )
+    XCTAssertEqual(tap.images, [info("https://e.com/tapped.png", "tapped")])
+    XCTAssertEqual(tap.currentIndex, 0)
+  }
+}


### PR DESCRIPTION
Adds a public `markdownImageTapHandler(_:)` view modifier + `MarkdownImageTapInfo` so host apps can receive taps on standalone (non link-wrapped) markdown images.

- Link-wrapped images (`[![alt](img)](link)`) keep their link behavior — no tap handler is attached, so link priority is structurally guaranteed.
- Backward compatible: without a handler in the environment, images stay non-interactive (no behavior change for existing consumers).
- Covers standalone images and images inside mixed paragraphs.

Required by the sendbird/ai-agent-ios markdown image click feature ([AA-15745](https://sendbird.atlassian.net/browse/AA-15745)).

## Changelog

**SendbirdMarkdownUI** — minor (new public API, backward compatible)

### Added
- `MarkdownImageTapInfo` — public value type carrying the tapped image's `url` and `alt`.
- `View.markdownImageTapHandler(_:)` — public view modifier; invoked when a standalone (non link-wrapped) markdown image is tapped. Applies to standalone images and images within mixed paragraphs.

### Behavior
- Link-wrapped images are excluded from the tap handler (link priority preserved).
- No handler set ⇒ images remain non-interactive (fully backward compatible).

### Files
- `Sources/MarkdownUI/Sources/MarkdownUI/Extensibility/MarkdownImageTapHandler.swift` (new)
- `Sources/MarkdownUI/Sources/MarkdownUI/Views/Inlines/ImageView.swift`
- `Sources/MarkdownUI/Sources/MarkdownUI/Views/Blocks/ParagraphView.swift`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[AA-15745]: https://sendbird.atlassian.net/browse/AA-15745?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ